### PR TITLE
Jiyoung : BOJ 2743 단어 길이 재기 / 11655 ROT13 / 10820 문자열 분석

### DIFF
--- a/jiyoung/home/2022-03-07/boj_10820.java
+++ b/jiyoung/home/2022-03-07/boj_10820.java
@@ -1,0 +1,72 @@
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.Scanner;
+
+/**
+ * [10820] 문자열 분석
+ * https://www.acmicpc.net/problem/10820
+ */
+public class boj_10820 {
+	public static void main(String[] args) throws IOException {
+		boj_10820 boj_10820 = new boj_10820();
+		boj_10820.bazzyung();
+//		boj_10820.boj(); // 백준 공유 코드
+	}
+	
+	public void bazzyung() throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		
+		String input = "";
+		
+		while((input = br.readLine()) != null) {
+			int[] arr = new int[4];
+			
+			for(int i = 0; i < input.length(); i++) {
+				if(input.charAt(i) >= 'a' && input.charAt(i) <= 'z') {
+					arr[0] += 1;
+				} else if(input.charAt(i) >= 'A' && input.charAt(i) <= 'Z') {
+					arr[1] += 1;
+				} else if(input.charAt(i) >= '0' && input.charAt(i) <= '9') {
+					arr[2] += 1;
+				} else if(input.charAt(i) == ' ') {
+					arr[3] += 1;
+				}
+			}
+			
+			for(int i : arr) {
+				bw.write(i + " ");
+			}
+			bw.write('\n');
+			
+			bw.flush();
+		}
+	}
+	
+	public void boj() {
+		Scanner sc = new Scanner(System.in);
+		while(sc.hasNextLine()) {
+			String str = sc.nextLine();
+			int lower = 0;
+			int upper = 0;
+			int digit = 0;
+			int space = 0;
+			for(int i = 0; i < str.length(); i++) {
+				char ch = str.charAt(i);
+				if('A' <= ch && ch <= 'Z') {
+					upper += 1;
+				} else if('a' <= ch && ch <= 'z') {
+					lower += 1;
+				} else if('0' <= ch && ch <= '9') {
+					digit += 1;
+				} else if(ch == ' ') {
+					space += 1;
+				}
+			}
+			System.out.println(lower + " " + upper + " " + digit + " " + space);
+		}
+	}
+}

--- a/jiyoung/home/2022-03-07/boj_11655.java
+++ b/jiyoung/home/2022-03-07/boj_11655.java
@@ -1,0 +1,72 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Scanner;
+
+/**
+ * [11655] ROT13
+ * https://www.acmicpc.net/problem/11655
+ */
+public class boj_11655 {
+	public static void main(String[] args) throws IOException {
+		boj_11655 boj_11655 = new boj_11655(); 
+		boj_11655.bazzyung();
+//		boj_11655.boj(); // 백준 공유 코드
+	}
+	
+	public void bazzyung() throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringBuilder sb = new StringBuilder(); 
+		
+		char[] rot13 = br.readLine().toCharArray();
+		
+		for(int i = 0; i < rot13.length; i++) {
+			if(rot13[i] >= 'A' && rot13[i] <= 'Z') {
+				if(rot13[i] >= 'N') {
+					rot13[i] -= 13;
+				} else {
+					rot13[i] += 13;
+				}
+			} else if(rot13[i] >= 'a' && rot13[i] <= 'z') {
+				if(rot13[i] >= 'n') {
+					rot13[i] -= 13;
+				} else {
+					rot13[i] += 13;
+				}
+			}
+		}
+		
+		for(char i : rot13) {
+			sb.append(i);
+		}
+		
+		System.out.println(sb);
+	}
+	
+	
+	public void boj() {
+		Scanner sc = new Scanner(System.in);
+		String s = sc.nextLine();
+		System.out.println(rot13(s));
+	}
+	
+	public static String rot13(String s) {
+		String ans = "";
+		for(int i = 0; i < s.length(); i++) {
+			char ch = s.charAt(i);
+			if(ch >= 'a' && ch <= 'm') {
+				ch += 13;
+			} else if(ch >= 'n' && ch <= 'z') {
+				ch -= 13;
+			} else if(ch >= 'A' && ch <= 'M') {
+				ch += 13;
+			} else if(ch >= 'N' && ch <= 'Z' ) {
+				ch -= 13;
+			}
+			
+			ans += ch;
+		}
+		
+		return ans;
+	}
+}

--- a/jiyoung/home/2022-03-07/boj_2743.java
+++ b/jiyoung/home/2022-03-07/boj_2743.java
@@ -1,0 +1,13 @@
+import java.util.Scanner;
+
+/**
+ * [2743] 단어 길이 재기
+ * https://www.acmicpc.net/problem/2743
+ */
+public class boj_2743 {
+	public static void main(String[] args) {
+		Scanner sc = new Scanner(System.in);
+		String str = sc.nextLine();
+		System.out.print(str.length());
+	}
+}


### PR DESCRIPTION
## 2743 단어 길이 재기
- 간만에 쉬운 문제 !  

    |메모리|시간|
    |:---:|:---:|
    |17652 KB|208 ms|


## 11655 ROT13
- 아스키코드를 활용
- 대문자와 소문자로 기준을 나누고 다시 각각 반으로 나누었을 때 'n(또는 N)' 보다 작거나 같을때는 13을 빼고, 그보다 클 때는 13을 더해주는 식으로 계산하였다.

    |메소드|메모리|시간|
    |:---:|:---:|:---:|
    |**bazzyung()**|15998 KB|156 ms|
    |**boj()**|14256 KB|100 ms|

## 10820 문자열 분석
- 길이가 4인 배열에 소문자, 대문자, 숫자, 공백이 순서대로 들어갈 수 있도록 하였다.
- 백준 공유 코드에서는 각 문자 형태에 맞는 변수 4개를 만들어 그 변수를 출력하는 형식으로 짜여 있었다.

    |메소드|메모리|시간|
    |:---:|:---:|:---:|
    |**bazzyung()**|14212 KB|124 ms|
    |**boj()**|15004 KB|128 ms|