### PR TITLE
yoonji : boj 1934 최소공배수/ 2609 최대공약수와최소공배수

### DIFF
--- a/yoonji/home/3/09/boj_1934.java
+++ b/yoonji/home/3/09/boj_1934.java
@@ -1,0 +1,40 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+
+public class boj_1934 {
+    public static void main(String[] args) throws IOException {
+        int bigger;
+        int smaller;
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int T = Integer.parseInt(br.readLine());
+        int[] num;
+        for (int i=0; i<T; i++) {
+            num = Arrays.stream(br.readLine().split(" ")).mapToInt(Integer::parseInt).toArray();
+            // 1. 대소 비교
+            if (num[0] >= num[1]) {
+                bigger = num[0];
+                smaller = num[1];
+            } else {
+                bigger = num[1];
+                smaller = num[0];
+            }
+            // 2. 최소공배수 호출
+            System.out.println(solveLCM(bigger, smaller));
+        }
+    }
+
+    // Largest Common Multiple 최소 공배수
+    public static int solveLCM(int bigger, int smaller) {
+        int multiple = 0;
+        int i=1;
+        // A의 배수가 B의 배수인지 체크
+        while(multiple <= bigger*smaller) {
+            multiple = bigger * i;
+            if (multiple % smaller == 0) break;
+            i++;
+        }
+        return multiple;
+    }
+}

--- a/yoonji/home/3/09/boj_2609.java
+++ b/yoonji/home/3/09/boj_2609.java
@@ -1,0 +1,60 @@
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Scanner;
+// 최대공약수와 최소공배수
+// 10,000이하의 자연수 2개가 주어지면, 최대공약수/최소공배수를 구한다.
+public class boj_2609 {
+    static List<Integer> divisor;
+    public static void main(String[] args) {
+        int bigger;
+        int smaller;
+        Scanner sc = new Scanner(System.in);
+        int[] num = Arrays.stream(sc.nextLine().split(" ")).mapToInt(Integer::parseInt).toArray();
+        // 1. 대소 비교
+        if (num[0] >= num[1]) {
+            bigger = num[0];
+            smaller = num[1];
+        }
+        else {
+            bigger = num[1];
+            smaller = num[0];
+        }
+        System.out.println(solveGCD(bigger, smaller));
+        System.out.println(solveLCM(bigger, smaller));
+    }
+
+    // Greatest Common Divisor 최대 공약수
+    public static int solveGCD(int bigger, int smaller) {
+        // 만약 같다면
+        if (bigger % smaller == 0) return smaller;
+        // B의 약수를 List에 추가하고 A에 가장 큰값부터 약수인지 체크
+        else {
+            divisor = new ArrayList<>(Arrays.asList(1));
+            for (int i= 2; i<smaller; i++) {
+                if (smaller % i == 0) divisor.add(i);
+            }
+            // smaller의 약수들 중 bigger의 약수 체크
+            int div = 0;
+            for (int i=divisor.size()-1; i>=0; i--) {
+                div = divisor.get(i);
+                if (bigger % div == 0) break;
+            }
+            return div;
+        }
+    }
+
+    // Largest Common Multiple 최소 공배수
+    public static int solveLCM(int bigger, int smaller) {
+        int multiple = 0;
+        int i=1;
+        // A의 배수가 B의 배수인지 체크
+        while(multiple <= bigger*smaller) {
+            multiple = bigger * i;
+            if (multiple % smaller == 0) break;
+            i++;
+        }
+        return multiple;
+    }
+}

--- a/yoonji/home/3/09/boj_2609.java
+++ b/yoonji/home/3/09/boj_2609.java
@@ -1,48 +1,62 @@
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Scanner;
 // 최대공약수와 최소공배수
 // 10,000이하의 자연수 2개가 주어지면, 최대공약수/최소공배수를 구한다.
+
+// 수정 : gcd_withEuclideanAlgorithm(), solveLCM_withGCD()
 public class boj_2609 {
     static List<Integer> divisor;
     public static void main(String[] args) {
-        int bigger;
-        int smaller;
         Scanner sc = new Scanner(System.in);
         int[] num = Arrays.stream(sc.nextLine().split(" ")).mapToInt(Integer::parseInt).toArray();
-        // 1. 대소 비교
-        if (num[0] >= num[1]) {
-            bigger = num[0];
-            smaller = num[1];
+        // 1. 대소 비교 (Math 라이브러리 이용하도록 수정)
+        int bigger = Math.max(num[0], num[1]);
+        int smaller = Math.min(num[0], num[1]);
+
+        int gcd = gcd_withEuclideanAlgorithm(bigger, smaller);  // 유클리드 호제법을 이용하여 구하는 메서드
+        System.out.println(gcd);
+//        System.out.println(solveGCD(bigger, smaller));
+//        System.out.println(solveLCM(bigger, smaller));
+        System.out.println(solveLCM_withGCD(bigger, smaller, gcd));
+    }
+    // 추가
+    private static int solveLCM_withGCD(int bigger, int smaller, int gcd) {
+        // 최소 공배수의 수학적 성질 : 두 수 a,b를 곱한 m을 최대공약수 gcd로 나누면 최소 공배수가 된다.
+        return (bigger * smaller) / gcd;
+    }
+
+    // 추가
+    private static int gcd_withEuclideanAlgorithm(int bigger, int smaller) {
+        // 두 자연수 a를 b로 나눈 나머지가 r이면, a,b의 최대 공약수 == b와 r의 최대공약수
+        // gcd(a, b)=gcd(b, r)
+        int r;
+        while (smaller != 0) {
+            r = bigger % smaller;
+            bigger = smaller;
+            smaller = r;
         }
-        else {
-            bigger = num[1];
-            smaller = num[0];
-        }
-        System.out.println(solveGCD(bigger, smaller));
-        System.out.println(solveLCM(bigger, smaller));
+        // smaller가 0이 되면
+        return bigger;
     }
 
     // Greatest Common Divisor 최대 공약수
     public static int solveGCD(int bigger, int smaller) {
+        int gcd=1;  // 공약수 1
         // 만약 같다면
         if (bigger % smaller == 0) return smaller;
-        // B의 약수를 List에 추가하고 A에 가장 큰값부터 약수인지 체크
+        // 두 수의 공약수를 한번에 구한다. (수정)
         else {
             divisor = new ArrayList<>(Arrays.asList(1));
             for (int i= 2; i<smaller; i++) {
-                if (smaller % i == 0) divisor.add(i);
+                if (smaller % i == 0 && bigger % i == 0) {
+                    gcd = i;
+                    break;
+                }
             }
-            // smaller의 약수들 중 bigger의 약수 체크
-            int div = 0;
-            for (int i=divisor.size()-1; i>=0; i--) {
-                div = divisor.get(i);
-                if (bigger % div == 0) break;
-            }
-            return div;
         }
+        return gcd;
     }
 
     // Largest Common Multiple 최소 공배수


### PR DESCRIPTION
## 1934 최소공배수
- 2609번에서 이용한 함수 그대로 사용하였다.

## 2609 최대공약수와최소공배수  **(수정)**
### 🅰️ 설계
- 최대공약수
1. smaller에 대해 2, smaller-1까지 나눠떨어지는 수를 모두 구한다.
2. 리스트의 뒤에서부터 bigger에 나눠떨어지는 값을 찾으면 바로 리턴한다.

> 수정 : `gcd_withEuclideanAlgorithm()` 참고
> 🏴󠁧󠁢󠁷󠁬󠁳󠁿  `유클리드 호제법` : 두 자연수 a를 b로 나눈 나머지가 r이면, a,b의 최대 공약수 == b와 r의 최대공약수

- 최소공배수
1. bigger에 대해 * i++을 진행하면서 smaller와 나눠떨어지면 바로 리턴한다.

> 수정 : `solveLCM_withGCD()` 참고
> 앞서 구한 gcd를 이용해서 lcm을 간편히 구할 수 있다.
> 🏴󠁧󠁢󠁷󠁬󠁳󠁿 `두 수 a,b를 곱한 m을 최대공약수 gcd로 나누면 최소 공배수가 된다.`

### 🅱️ 후기
- 피드백 후의 코드 길이가 거의 400줄 이상이 줄었다. 👍 
- 수학적으로 접근하는 것이 더 이과적인 방법이고, 평가 입장에서도 똑똑하게 볼것같다 (?)