### PR TITLE
yoonji : boj 9095 1,2,3 더하기 / 11727 2*n 타일2 / 11052 카드 구매하기

### DIFF
--- a/yoonji/home/3/18/boj_11052.java
+++ b/yoonji/home/3/18/boj_11052.java
@@ -1,0 +1,32 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+// 카드 구매하기
+// 배열에 들어갈 값: index개 구할 때 최대 비용
+// 카드 N개 구매할 때 비용의 최댓값을 구한다.
+public class boj_11052 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int N = Integer.parseInt(br.readLine());
+        int[] dp = new int[N+1];    // N이 1일 때 dp[2]에 대해 outOfBounds 에러가 나지 않도록 하기 위해
+        int[] cardpackPrice = new int[N+1];
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for (int i=1; i<N+1; i++) {
+            cardpackPrice[i] = Integer.parseInt(st.nextToken());
+        }
+
+        int max = Integer.MIN_VALUE;
+        // 카드팩 i일 때 최대 값구한다.
+        // ex) i=3 :3개의 카드를 구매하는 경우
+        for (int i=1; i<=N; i++) {
+            // 카드팩 i를 만드는 경우의 수를 돌며 최댓값을 비교하여 구한다.
+            // ex) j=1 : dp[2]+P[1]-> 카드2개의최댓값+카드1개값 / j=2 : dp[1]+P[2]-> 카드1개의 최댓값+카드2개값 / j=3 : dp[0]+P[3] ->P3가격
+            for (int j=1; j<=i; j++)  {
+                dp[i] = Math.max(dp[i], dp[i - j] + cardpackPrice[j]);
+            }
+        }
+        System.out.println(dp[N]);
+    }
+}

--- a/yoonji/home/3/18/boj_11727.java
+++ b/yoonji/home/3/18/boj_11727.java
@@ -1,0 +1,2 @@
+package PACKAGE_NAME;public class boj_11727 {
+}

--- a/yoonji/home/3/18/boj_11727.java
+++ b/yoonji/home/3/18/boj_11727.java
@@ -1,2 +1,19 @@
-package PACKAGE_NAME;public class boj_11727 {
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+// 2*n 타일 2
+public class boj_11727 {
+    private static final int MOD = 10007;   //modulo(나머지연산)
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int N = Integer.parseInt(br.readLine());
+        int[] dp = new int[N+2];    // N이 1일 때 dp[2]에 대해 outOfBounds 에러가 나지 않도록 하기 위해
+        dp[1] = 1;
+        dp[2]= 3;
+        for (int i=3; i<=N; i++) {
+            dp[i] = (dp[i-1] + dp[i-2]*2) % MOD;
+        }
+        System.out.println(dp[N]);
+    }
 }

--- a/yoonji/home/3/18/boj_9095.java
+++ b/yoonji/home/3/18/boj_9095.java
@@ -1,0 +1,2 @@
+package PACKAGE_NAME;public class boj_9095 {
+}

--- a/yoonji/home/3/18/boj_9095.java
+++ b/yoonji/home/3/18/boj_9095.java
@@ -1,2 +1,51 @@
-package PACKAGE_NAME;public class boj_9095 {
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+// 1,2,3 더하기
+// 1 : 1 (1)
+// 2 : 2 (1+1, 2)
+// 3 : 4 (1+1+1, 1+2, 2+1, 3)
+// 4 : 7 (1+1+1+1, 1+1+2, 2+2, 1+3
+// 점화식 : D[N] = D[N-1] + D[N-2] + D[N-3]
+// 규칙을 통해점화식을 찾아내기 힘들었음
+public class boj_9095 {
+    public static void main(String[] args) throws IOException {
+        StringBuilder sb = new StringBuilder();
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int T = Integer.parseInt(br.readLine());
+        int[] dp= new int[12];  // n<11이므로 미리 초기화
+        dp[1] = 1;
+        dp[2] = 2;
+        dp[3] = 4;
+/*        memo[1] = 1;
+        memo[2] = 2;
+        memo[3] = 4;*/
+        int forCnt = 0;
+        for (int i=0; i<T; i++) {
+            int n = Integer.parseInt(br.readLine());
+//            sb.append(recursion(n)).append("\n");
+            // 1. for문 & bottom up
+            for (int j = 4; j <= n; j++) {
+                dp[j] = dp[j-3] + dp[j-2] + dp[j-1];
+//                System.out.println("호출 횟수 체크 " + forCnt++);   // 11번 호출
+            }
+            sb.append(dp[n]).append("\n");
+        }
+        System.out.println(sb);
+    }
+
+    // 2. memoize_recursion &  top down
+    static int cnt =0;
+    static int memoCnt =0;
+    static int[] memo = new int[12];
+    private static int recursion(int n) {
+//        System.out.println("재귀 횟수 체크" + cnt++);   // 87번 호출
+        if (memo[n]>0) return memo[n];
+//        System.out.println("memoize를 이용하면? " + memoCnt++);  // + memoize를 이용하면 for문까지 들어오는 경우는 6번
+        for (int i=n; i>3; i--) {
+            memo[i] = recursion(i-1) + recursion(i-2) + recursion(i-3);
+        }
+        return memo[n];
+    }
 }


### PR DESCRIPTION
## 9095 1,2,3 더하기
- 1,2,3으로 N을 만드는 경우의 수
- 주석에서
`1.`  for문으로 푼 경우
`2.`  재귀 + memoization으로 푼 경우
=> 백준 채점현황에서는 2번이 조금 더 효율이 높다.

## 11727 2*n 타일2
### 🅰️ 설계
2x1로 도출
1x2로 도출
2x2로 도출
1x2와 2x2를 섞은 조합으로 도출
예시👇 
2x1 : 1
2x2 : 3
2x3 : 5 = dp[1]*2 + dp[2]
2x4 : 11 = dp[2]*2 + dp[3]
2x5 : 21 = dp[3]*2 + dp[4]

**점화식 D[N] = D[N-1] + D[N-2]*2**

### 🅱️ 후기
- 1x2와 2x2 섞은 조합을 생각하지 못했음

## 11052 카드 구매하기
### 🅰️ 설계
- 모든 경우의 수에 대해 최댓값으로 지정한다.
- DP 배열의 index는 카드의 갯수를, 값에는 최댓값을 넣는다.
- 카드 i개를 살 때 카드 i개를 만들 수 있는 모든 카드 조합의 경우의 수를 구해서 최댓값을 구한다.

### 🅱️ 후기
- 바깥 for문을 각각의 카드 구매 갯수를 기준으로 두고, `이중 for문`을 돌아야겠다까지는 갔는데.. 내부 for문을 어떻게 둬야할지 답이 안나왔다.
- 결정적으로 점화식 정의하지 못함