### PR TITLE
yoonji : boj 2193 이친수

### DIFF
--- a/yoonji/home/3/19/boj_10844_2ndTry.java
+++ b/yoonji/home/3/19/boj_10844_2ndTry.java
@@ -1,0 +1,2 @@
+package PACKAGE_NAME;public class boj_10844_2ndTry {
+}

--- a/yoonji/home/3/21/boj_11053.java
+++ b/yoonji/home/3/21/boj_11053.java
@@ -1,39 +1,39 @@
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
-import java.io.IOException;
-import java.util.StringTokenizer;
+    import java.io.BufferedReader;
+    import java.io.InputStreamReader;
+    import java.io.IOException;
+    import java.util.StringTokenizer;
 
-// 가장 긴 증가하는 부분 수열
-// 10,20,10,30,20,50 에서
-// 10,30,50 보다는 10,20,30,50 이 정답 => 4
-// 전 값보다 작은 값이고 수열의 길이수도 더 적은 상태이면 ++
-// D[N] = 길이가 N일 때 가장 긴 수열의 갯수
-public class boj_11053 {
-    public static void main(String[] args) throws IOException {
-        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
-        int A = Integer.parseInt(br.readLine());
-        StringTokenizer st = new StringTokenizer(br.readLine(), " ");
-        int[] nums = new int[A + 1];
-        int[] dp = new int[A + 1];    //1개~A개
+    // 가장 긴 증가하는 부분 수열
+    // 10,20,10,30,20,50 에서
+    // 10,30,50 보다는 10,20,30,50 이 정답 => 4
+    // 전 값보다 작은 값이고 수열의 길이수도 더 적은 상태이면 ++
+    // D[N] = 길이가 N일 때 가장 긴 수열의 갯수
+    public class boj_11053 {
+        public static void main(String[] args) throws IOException {
+            BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+            int A = Integer.parseInt(br.readLine());
+            StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+            int[] nums = new int[A + 1];
+            int[] dp = new int[A + 1];    //1개~A개
 
-        for (int i = 1; i <= A; i++)
-            nums[i] = Integer.parseInt(st.nextToken());
-        // 기본으로 모두 배열의 길이는 1
-        for (int i = 0; i <= A; i++) dp[i] = 1;
+            for (int i = 1; i <= A; i++)
+                nums[i] = Integer.parseInt(st.nextToken());
+            // 기본으로 모두 배열의 길이는 1
+            for (int i = 0; i <= A; i++) dp[i] = 1;
 
-        int max = Integer.MIN_VALUE;
-        // 이중 for문 : i보다 앞에 위치한 j들과 비교
-        for (int i = 2; i <= A; i++) {
-            for (int j = 1; j < i; j++) {
-                // 1. 뒤의 값(i)이 더 커야 한다.
-                // 2. 동시에 크기가 더 큰 값의 부분수열의 길이(dp[i])가 작은 값의 수열길이+1(dp[j]+1)보다 작으면, 부분수열에 포함되지 않은것이므로 +1
-                // 1,2 조건 모두 충족 시 부분 수열에 포함됨
-                if (nums[j] < nums[i] && dp[j] + 1 > dp[i])
-                    dp[i] = dp[j] + 1;
+            int max = 1;    // input이 최솟값 1일 때 for문을 돌지 않을 수 있으므로 max 값은 1로 초기화.
+            // 이중 for문 : i보다 앞에 위치한 j들과 비교
+            for (int i = 2; i <= A; i++) {
+                for (int j = 1; j < i; j++) {
+                    // 1. 뒤의 값(i)이 더 커야 한다.
+                    // 2. 동시에 크기가 더 큰 값의 부분수열의 길이(dp[i])가 작은 값의 수열길이+1(dp[j]+1)보다 작으면, 부분수열에 포함되지 않은것이므로 +1
+                    // 1,2 조건 모두 충족 시 부분 수열에 포함됨
+                    if (nums[j] < nums[i] && dp[j] + 1 > dp[i])
+                        dp[i] = dp[j] + 1;
+                }
+                // 가장 긴 부분 수열 갯수를 return해야하므로
+                max = Math.max(max, dp[i]);
             }
-            // 가장 긴 부분 수열 갯수를 return해야하므로
-            max = Math.max(max, dp[i]);
+            System.out.println(max);
         }
-        System.out.println(max);
     }
-}

--- a/yoonji/home/3/21/boj_11053.java
+++ b/yoonji/home/3/21/boj_11053.java
@@ -14,13 +14,13 @@ public class boj_11053 {
         int A = Integer.parseInt(br.readLine());
         StringTokenizer st = new StringTokenizer(br.readLine(), " ");
         int[] nums = new int[A + 1];
+        int[] dp = new int[A + 1];    //1개~A개
+
         for (int i = 1; i <= A; i++)
             nums[i] = Integer.parseInt(st.nextToken());
-        int[] dp = new int[A + 1];    //1개~A개
         // 기본으로 모두 배열의 길이는 1
-        for (int i = 1; i <= A; i++) dp[i] = 1;
+        for (int i = 0; i <= A; i++) dp[i] = 1;
 
-        dp[1] = 1;
         int max = Integer.MIN_VALUE;
         // 이중 for문 : i보다 앞에 위치한 j들과 비교
         for (int i = 2; i <= A; i++) {

--- a/yoonji/home/3/21/boj_11053.java
+++ b/yoonji/home/3/21/boj_11053.java
@@ -1,2 +1,39 @@
-package PACKAGE_NAME;public class boj_11053 {
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.IOException;
+import java.util.StringTokenizer;
+
+// 가장 긴 증가하는 부분 수열
+// 10,20,10,30,20,50 에서
+// 10,30,50 보다는 10,20,30,50 이 정답 => 4
+// 전 값보다 작은 값이고 수열의 길이수도 더 적은 상태이면 ++
+// D[N] = 길이가 N일 때 가장 긴 수열의 갯수
+public class boj_11053 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int A = Integer.parseInt(br.readLine());
+        StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+        int[] nums = new int[A + 1];
+        for (int i = 1; i <= A; i++)
+            nums[i] = Integer.parseInt(st.nextToken());
+        int[] dp = new int[A + 1];    //1개~A개
+        // 기본으로 모두 배열의 길이는 1
+        for (int i = 1; i <= A; i++) dp[i] = 1;
+
+        dp[1] = 1;
+        int max = Integer.MIN_VALUE;
+        // 이중 for문 : i보다 앞에 위치한 j들과 비교
+        for (int i = 2; i <= A; i++) {
+            for (int j = 1; j < i; j++) {
+                // 1. 뒤의 값(i)이 더 커야 한다.
+                // 2. 동시에 크기가 더 큰 값의 부분수열의 길이(dp[i])가 작은 값의 수열길이+1(dp[j]+1)보다 작으면, 부분수열에 포함되지 않은것이므로 +1
+                // 1,2 조건 모두 충족 시 부분 수열에 포함됨
+                if (nums[j] < nums[i] && dp[j] + 1 > dp[i])
+                    dp[i] = dp[j] + 1;
+            }
+            // 가장 긴 부분 수열 갯수를 return해야하므로
+            max = Math.max(max, dp[i]);
+        }
+        System.out.println(max);
+    }
 }

--- a/yoonji/home/3/21/boj_11053.java
+++ b/yoonji/home/3/21/boj_11053.java
@@ -1,0 +1,2 @@
+package PACKAGE_NAME;public class boj_11053 {
+}

--- a/yoonji/home/3/21/boj_14002.java
+++ b/yoonji/home/3/21/boj_14002.java
@@ -1,0 +1,48 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+// 가장 긴 증가하는 부분 수열 4
+public class boj_14002 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int A = Integer.parseInt(br.readLine());
+        StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+        int[] nums = new int[A + 1];
+        int[] dp = new int[A + 1];    //1개~A개
+        // 1.초기화
+        for (int i = 1; i <= A; i++)
+            nums[i] = Integer.parseInt(st.nextToken());
+        for (int i = 0; i <= A; i++) dp[i] = 1;
+        int max = 1;    // input이 최솟값 1일 때 for문을 돌지 않을 수 있으므로 max 값은 1로 초기화.
+
+        // 2. dp 값 구하기 : 이중 for문 : i보다 앞에 위치한 j들과 비교
+        for (int i = 2; i <= A; i++) {
+            for (int j = 1; j < i; j++) {
+                // 1. 뒤의 값(i)이 더 커야 한다.
+                // 2. 동시에 크기가 더 큰 값의 부분수열의 길이(dp[i])가 작은 값의 수열길이+1(dp[j]+1)보다 작으면, 부분수열에 포함되지 않은것이므로 +1
+                // 1,2 조건 모두 충족 시 부분 수열에 포함됨
+                if (nums[j] < nums[i] && dp[j] + 1 > dp[i]) {
+                    dp[i] = dp[j] + 1;
+                }
+            }
+            // 가장 긴 부분 수열 갯수를 알아야하므로
+            max = Math.max(max, dp[i]);
+        }
+        // 답 출력 : 수열길이 + 부분 수열 출력
+        System.out.println(max);
+        List<Integer> ans = new ArrayList<>();
+        for (int i=dp.length-1; i>=1; i--) {
+            if (max == 0) break;
+            if (max == dp[i]) {
+                ans.add(nums[i]);
+                max--;
+            }
+        }
+        for (int i=ans.size()-1; i>=0; i--)
+            System.out.print(ans.get(i) +" ");
+    }
+}

--- a/yoonji/home/3/21/boj_2193.java
+++ b/yoonji/home/3/21/boj_2193.java
@@ -1,0 +1,37 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+// 이친수
+// N자리 이친수의 개수를 구하자.
+// D[N] : N자리 이친수 갯수
+// 자릿수 N의 자리는 1밖에 못온다.
+// 자릿수 N인 자릿값이 1 앞에는 0밖에 못온다.
+// 0 앞에는 1, 0 둘다 올 수 있다.
+// 자릿수와 자릿값을 위해 이차원 배열로 나타낸다.
+public class boj_2193 {
+    static int N;
+    static long[][] dp;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        N = Integer.parseInt(br.readLine());
+        dp = new long[N + 1][2]; // 0과 1
+        // 마지막 자릿수는 경우의 수 1?
+        dp[1][0] =1L;
+        dp[1][1] =1L;
+        for (int i = 0; i <= 1; i++) {  // N의 자릿값(0,1)을 돌며
+            recur(N, i);
+        }
+        System.out.println(dp[N][1]);
+    }
+
+    private static long recur(int digit, int value) {
+        if (digit == 1) return dp[digit][value];    // 자릿수가 1인 경우
+        if (digit == N && value == 0) return dp[digit][value];   // 자릿수가 N이면서 값이 0인 경우
+        if (dp[digit][value] == 0) {
+            if (value == 1) dp[digit][value] = recur(digit-1, 0);   // 1이면 앞에 0만 올 수 있음
+            else dp[digit][value] = recur(digit-1, 0) + recur(digit-1, 1);  // 0이면 1과 0 올 수 있음
+        }
+        return dp[digit][value];
+    }
+}

--- a/yoonji/office/3/22/prg_124나라의숫자.java
+++ b/yoonji/office/3/22/prg_124나라의숫자.java
@@ -1,0 +1,2 @@
+package PACKAGE_NAME;public class prg_124나라의숫자 {
+}

--- a/yoonji/office/3/22/prg_3진법뒤집기.java
+++ b/yoonji/office/3/22/prg_3진법뒤집기.java
@@ -1,0 +1,2 @@
+package PACKAGE_NAME;public class prg_3진법뒤집기 {
+}

--- a/yoonji/office/3/22/prg_로또.java
+++ b/yoonji/office/3/22/prg_로또.java
@@ -1,0 +1,2 @@
+package PACKAGE_NAME;public class prg_로또 {
+}

--- a/yoonji/office/3/22/prg_약수개수와덧셈.java
+++ b/yoonji/office/3/22/prg_약수개수와덧셈.java
@@ -1,0 +1,2 @@
+package PACKAGE_NAME;public class prg_약수개수와덧셈 {
+}


### PR DESCRIPTION
## 2193 이친수
- D[N] : N자리 이친수 갯수
- 자릿값과 자릿수를 이차원으로 표현하였다.
- 이외 설명은 주석으로 작성하였습니다.

## 11053 가장 긴 증가하는 부분 수열
### 설계
1. 모두 배열의 길이를 1로 설정 (최소 배열의 길이는 1)
2. 이중 for문 : i보다 앞에 위치한 j들과 비교
2-1. 뒤의 값(i)이 더 커야 한다.
2-2. 동시에 크기가 더 큰 값의 부분수열의 길이(dp[i])가 작은 값의 수열길이+1(dp[j]+1)보다 작으면, 부분수열에 포함되지 않은것이므로 +1
2-3. 조건 모두 충족 시 부분 수열에 포함됨
2-4. 내부 for문 종료 시, max값을 뽑아서 가장 긴 부분 수열의 상태를 업데이트함.

⚠️  input이 최솟값 1일 때 for문을 돌지 않으므로 max 값은 1로 초기화해야 올바른 답이 나옴. 

## 14002 가장 긴 증가하는 부분 수열 4 
### 설계
- 11053 문제에서 로직 추가
- 가장 긴 증가하는 수열에 해당하는 수들을 출력하기 위해 배열 `dp`를 뒤에서부터 순차적으로 방문하며 max값과 일치하는 인덱스에 해당하는 `nums` 배열 원소를 list에 추가하였다.
- 값들을 출력 : 뒤에서부터 출력해주었다.