### PR TITLE
yoonji: boj 9465 스티커 / 2156 포도주시식

### DIFF
--- a/yoonji/home/3/25/boj_2156.java
+++ b/yoonji/home/3/25/boj_2156.java
@@ -1,2 +1,33 @@
-package PACKAGE_NAME;public class boj_2156 {
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+// 포도주 시식
+// 연속 3개의 포도주를 잡지 않도록 하는 것을 어떻게 처리해야할지 고민이 되었다
+// 포함한 경우와 포함시키지 않는 경우로 구분해야겠다 생각했다.
+// 이를 코드로 구현하는 과정에서 막혔다.
+// 포함하는 경우 : dp[i-3] + arr[i-1] +arr[i]와 dp[i-2] + arr[i] : 3전의 최댓값 + -1전+현재 vs 2전의 최댓값+현재
+// 포함하지 않는 경우 : dp[i-1]
+// 의 max를 찾는다.
+// 점화식 : DP[N] = N까지의 포도주 양 최댓값 (자리 N의 포도주를 포함한 경우와 포함하지 않은 경우의 최댓값을 구한다.)
+public class boj_2156 {
+    public static void main(String[] args) throws IOException{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int N = Integer.parseInt(br.readLine());
+        int[] dp = new int[N+1];
+        int[] grapesJuice = new int[N+1];
+        // 1. 초기화
+        for (int i=1; i<=N; i++) {
+            grapesJuice[i] = Integer.parseInt(br.readLine());
+        }
+        dp[1] = grapesJuice[1];
+        // N이 1보다 클 때에만 dp[2]도 설정 가능 -> 연속 2개 해도, 3부터 line28-29처럼 진행하므로 상관없음.
+        if (N > 1) dp[2] = grapesJuice[1] + grapesJuice[2];
+        // 2. dp구하기
+        for (int i=3; i<=N; i++) {
+            int includingIMax = Math.max(dp[i-3]+ grapesJuice[i-1]+grapesJuice[i], dp[i-2]+grapesJuice[i]);
+            dp[i] = Math.max(dp[i - 1], includingIMax);
+        }
+        System.out.println(dp[N]);
+    }
 }

--- a/yoonji/home/3/25/boj_2156.java
+++ b/yoonji/home/3/25/boj_2156.java
@@ -1,0 +1,2 @@
+package PACKAGE_NAME;public class boj_2156 {
+}

--- a/yoonji/home/3/25/boj_9465.java
+++ b/yoonji/home/3/25/boj_9465.java
@@ -1,0 +1,51 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+// 스티커
+public class boj_9465 {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static int[][] dp;
+    public static void main(String[] args) throws IOException {
+        StringBuilder sb = new StringBuilder();
+        int T = Integer.parseInt(br.readLine());
+
+        for (int i = 0; i < T; i++) {
+            int N = Integer.parseInt(br.readLine());
+            // 1. 초기화
+            int[][] stickers = new int[3][N + 1];
+            dp = new int[3][N + 1];
+            for (int j=1; j<=2; j++) {
+                int idx = 0;
+                StringTokenizer st = new StringTokenizer(br.readLine());
+                while(st.hasMoreTokens()) stickers[j][++idx] = Integer.parseInt(st.nextToken());
+            }
+            dp[1][1] = stickers[1][1];
+            dp[2][1] = stickers[2][1];
+
+            // 2. dp 구하기 : 현재 위치에서는 각 크로스되는 층의 "전, 전전 최댓값"만 고려하면 된다.
+            // 더 전의 것만을 고려하게 되면 전과 전전의 값을 고려하지 못한 최댓값이 된다.
+            for (int k=2; k<=N; k++) {
+                dp[1][k] = Math.max(dp[2][k - 1], dp[2][k - 2]) + stickers[1][k];
+                dp[2][k] = Math.max(dp[1][k - 1], dp[1][k - 2]) + stickers[2][k];
+            }
+            /* 내 풀이(시간초과) : 해당 값에 대해 모든 dp의 최댓값을 구하는 방식
+            for (int k=2; k<=N; k++) {
+                int max = getCommonMaxDp(k);
+                dp[1][k] = Math.max(max, dp[2][k-1]) + stickers[1][k];
+                dp[2][k] = Math.max(max, dp[1][k-1])+ stickers[2][k];
+            }*/
+            sb.append(Math.max(dp[1][N], dp[2][N])).append("\n");
+        }
+        System.out.println(sb);
+    }
+
+    private static int getCommonMaxDp(int k) {
+        int max = 0;
+        for (int i=1; i<=2; i++)
+            for (int j=1; j<k-1; j++) {
+                max = Math.max(max, dp[i][j]);
+            }
+        return max;
+    }
+}


### PR DESCRIPTION
## 9465 스티커
### 후기
- 참고한 풀이는 대각선의 `dp[i-1]`와 `dp[i-2]`중 max값으로 값을 구하는데, 더 그 전의 것을 고려하게 되면 대각선에 있는 `i-1`과 `i-2`가 고려되지 않은 dp가 된다.
- 내 풀이(시간초과) : 해당 값까지 오는데에 모든 dp 중 최댓값을 구하는 방식
  - dp는 작은 문제로 큰 문제를 해결할 수 있다는 점에서 효율이 있는 방식인데, dp의 관점으로 문제를 해결하지 못하고 있는 듯하다. (특히 이번 풀이는 완전탐색으로 푼듯하다)

## 2156 포도주시식
- 점화식 : DP[N] = N까지의 포도주 양 최댓값 (자리 N의 포도주를 포함한 경우와 포함하지 않은 경우의 최댓값을 구한다.)
### 후기
- 연속 3개의 포도주를 잡지 않도록 하는 것을 어떻게 처리해야할지 고민하였고, N을 `포함한 경우`와 `포함시키지 않는 경우`로 구분해야겠다 생각했다.
  - 이를 코드로 구현하는 과정에서 막혔다.
아래 중 max값을 찾는다.
- 포함하는 경우 : 3전의 최댓값 + -1전+현재 vs 2전의 최댓값+현재  `dp[i-3] + arr[i-1] +arr[i]`  VS. `dp[i-2] + arr[i] `
- 포함하지 않는 경우 : `dp[i-1]` (전 위치의 포도주까지의 최댓값과 동일한 값으로 지정)

## 1932 정수 삼각형
예정