### PR TITLE
yoonji: boj 9095 1,2,3 더하기(Brute Force) / 15649 N과 M(1) / 15650 N과 M(2)

### DIFF
--- a/yoonji/home/4/01/boj_15649.java
+++ b/yoonji/home/4/01/boj_15649.java
@@ -1,2 +1,63 @@
-package PACKAGE_NAME;public class boj_15649 {
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+// N과 M (1)
+public class boj_15649 {
+    static StringBuilder answer = new StringBuilder();
+    static int[] oneLine; // line별
+    static boolean[] visited;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int N = Integer.parseInt(st.nextToken());
+        int length = Integer.parseInt(st.nextToken());
+
+        visited = new boolean[N];
+        oneLine = new int[length];
+        dfs(N, length, 0);
+        System.out.println(answer);
+    }
+
+    private static void dfs(int num, int length, int depth) {
+        if (depth == length) {  // 깊이 끝까지 왔다면 해당 line에 해당하는 oneLine배열을 answer에 추가
+            for (int n: oneLine)
+                answer.append(n).append(" ");
+            answer.append("\n");
+            return;
+        }
+        // oneLine은 아래에서 다시 덮어씌워지므로 초기화할 필요 없음.
+        for (int i=0; i<num; i++){
+            // 방문 안한 경우 (방문했다면 한 line에서 중복되는 수이므로 방문X)
+            if (!visited[i]) {
+                visited[i] = true;
+                oneLine[depth] = i+1;   // 현재 depth에 i+1값 저장
+                dfs(num, length, depth+1);  // 그다음에 올 수 재귀호출
+                visited[i] = false;// length 만큼 돌았을테니 다음 line을 위해 다시 visited[i]= false
+            }
+        }
+    }
 }
+
+// 내 풀이
+// 중복은 아래 조건문으로 피하고자했다.
+// if (depth>0 && sb.toString().contains(String.valueOf(num))) return;
+// 하지만 아래와 같이 출력된다..
+// 4 2를 입력했을 떄
+// 1 2
+// 3
+// 4
+// 2 1
+// 2
+// 3
+// 4
+// 3 1
+// 2
+// 3
+// 4
+// 4 1
+// 2
+// 3
+// 4
+// dfs 문제 풀 때는 방문 여부를 나타내는 boolean배열을 활용하는 것이 좋다. 다시 풀어보았다.

--- a/yoonji/home/4/01/boj_15650.java
+++ b/yoonji/home/4/01/boj_15650.java
@@ -1,0 +1,36 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+// N과 M (2)
+// 오름차순으로 탐색하면 되므로 중복을 피하기위해 사용하는 visited는 필요 X
+// 오름차순 증가를 위해 dfs 내의 for문은 현재 수부터 탐색하도록하여 +1된 값을 dfs로 호출한다.
+// depth가 채워지기전에 N을 넘어서 반복문이 끝나 자동으로 걸러진다.
+public class boj_15650 {
+    static StringBuilder sb = new StringBuilder();
+    static int[] line;
+    static int N, limit;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+        N = Integer.parseInt(st.nextToken());
+        limit = Integer.parseInt(st.nextToken());
+
+        line = new int[limit];
+        dfs(0, 1);
+        System.out.println(sb);
+    }
+
+    private static void dfs(int depth, int now) {
+        if (depth == limit) {
+            for (int n : line) sb.append(n).append(" ");
+            sb.append("\n");
+            return;
+        }
+        for (int i=now; i<= N; i++) {
+            line[depth] = i;
+            dfs(depth + 1, i + 1);    // 현재 값보다 1 큰 값부터 탐색하도록 재귀호출
+        }
+    }
+}

--- a/yoonji/home/4/01/boj_9095_BruteForce.java
+++ b/yoonji/home/4/01/boj_9095_BruteForce.java
@@ -1,2 +1,30 @@
-package PACKAGE_NAME;public class boj_9095_BruteForce {
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+// 너무 복잡하게 생각하지 않아도된다..
+// dfs는 인자로 어떤 값을 줄지 고민하는 것이 어렵다.
+public class boj_9095_BruteForce {
+    static int cnt;
+    static int N;
+    public static void main(String[] args) throws IOException {
+        StringBuilder sb = new StringBuilder();
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int T = Integer.parseInt(br.readLine());
+        for (int i=0; i<T; i++) {
+            N = Integer.parseInt(br.readLine());
+            cnt = 0;
+            dfs(0);
+            sb.append(cnt).append("\n");
+        }
+        System.out.println(sb);
+    }
+    private static void dfs(int sum) {
+        // 조건을 추가하여 가지치기
+        if (sum == N) { // sum이 N과 같아지면 cnt++
+            cnt++;
+            return;
+        }
+        if (sum > N) return;
+        for (int i = 1; i <= 3; i++) dfs(sum + i);
+    }
 }


### PR DESCRIPTION
## 9095 1,2,3 더하기
### 🅰️ 설계
1. T만큼 반복문을 돈다.
2. sum이 0인 상태로 dfs를 호출한다.
3. dfs 내에서 1,2,3을 반복하며 sum에 더하여
  3-1. dfs를 재귀호출하는데 if문에 의해 sum이 목표값이 되거나 지나치면 return하여 해당 재귀는 중단한다.

## 15649 N과 M (1)
### 🅰️ 후기
- 중복되는 수를 피하고자 조건문을 추가했지만, 원하는 대로 답이 출력되지 않았다.
- 방문을 체크하는 배열 `visited`를 이용해서 중복을 피할 수 있었다.
- dfs로 푸는 것에  더 익숙해져야함을 느낀다.

## 15650 N과 M (2)
### 🅰️ 후기
- N과 M(1)을 풀고 N과 M(2)를 푸니 접근 방식이 중요하다는 걸 느꼈다
- 전자는 중복인 경우를 고려해야하므로 visited 방문 배열을 이용했지만
  - 이번에는 중복을 고려해야하지만 오름차순으로 정렬하면 되기 때문에 for문의 시작을 현재 숫자값으로 지정하기만 하면 된다.