### PR TITLE
Jeongwoo: BOJ 6064 카잉 달력, BOJ 1748 수 이어 쓰기 1

### DIFF
--- a/jeongwoo/home/2022-03/30/Boj1476.java
+++ b/jeongwoo/home/2022-03/30/Boj1476.java
@@ -1,0 +1,57 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+/**
+ * [1476] 날짜 계산
+ * https://www.acmicpc.net/problem/1476
+ *
+ * -아이디어
+ * 1. 각 자리는 15, 28, 19 주기로 돌아감
+ * 2. 1, 2, 3인 경우
+ * 3. -> 1은 15로 나누었을 때 나머지가 1인 숫자들의 집합 1, 16, 31, ..., 5266, ...
+ * 4. -> 2는 28로 나누었을 때 나머지가 2인 숫자들의 집합 2, 30, 58, ..., 5666, ...
+ * 5. -> 3은 19로 나누었을 때 나머지가 3인 숫자들의 집합 3, 22, 41, ..., 5666, ...
+ * 6. 나머지가 각 자리 수인 숫자들의 집합 중에 같은 자리에 같은 숫자가 나올 때까지 돌린다.
+ * 7. 그러나 각 자리 수가 15, 28, 19인 경우 15 % 15 = 0이 돼서 못 찾으니까 0으로 바꿔야 한다.
+ * 
+ * -시간 복잡도
+ * 1.
+ *
+ * -자료 구조
+ * 1.
+ */
+
+public class Boj1476 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int[] arr = new int[3];
+
+        for (int i = 0; i < arr.length; i++) {
+            arr[i] = Integer.parseInt(st.nextToken());
+        }
+
+        int years = 1;
+
+        if (arr[0] == 15) {
+            arr[0] = 0;
+        }
+        if (arr[1] == 28) {
+            arr[1] = 0;
+        }
+        if (arr[2] == 19) {
+            arr[2] = 0;
+        }
+
+        while ((arr[0] != years % 15) || (arr[1] != years % 28) || (arr[2] != years % 19)) {
+            years++;
+        }
+
+        System.out.println(years);
+
+
+
+    }
+}

--- a/jeongwoo/home/2022-03/31/Boj1748.java
+++ b/jeongwoo/home/2022-03/31/Boj1748.java
@@ -1,0 +1,68 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+/**
+ * [1748] 수 이어 쓰기 1
+ * https://www.acmicpc.net/problem/1748
+ *
+ * -아이디어
+ * 1. n을 입력 받으면 1부터 n까지 숫자 이어 쓰기
+ * 2. 1부터 n까지 숫자를 다 입력 받지 말고 자릿수만 계산하면 된다
+ * 3. n은 최대 1억이니까 일, 십, 백, 천, 만, 십만, 백만, 천만, 억 자릿수 + 십억 하나
+ *
+ * -시간 복잡도
+ * 1.
+ *
+ * -자료 구조
+ * 1.
+ */
+
+public class Boj1748 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+        StringBuilder sb = new StringBuilder();
+        int ans = 0;
+
+        for (int i = 1; i <= n; i++) {
+            // 1의 자리
+            if (i >= 1 && i < 10) {
+                ans += 1;
+            }
+            // 10의 자리
+            else if (i >= 10 && i < 100) {
+                ans += 2;
+            }
+            //100의 자리
+            else if (i >= 100 && i < 1000) {
+                ans += 3;
+            }
+            // 1,000의 자리
+            else if (i >= 1000 && i < 10000) {
+                ans += 4;
+            }
+            // 10,000의 자리
+            else if (i >= 10000 && i < 100000) {
+                ans += 5;
+            }
+            // 100,000
+            else if (i >= 100000 && i < 1000000) {
+                ans += 6;
+            }
+            // 1,000,000
+            else if (i >= 1000000 && i < 10000000) {
+                ans += 7;
+            }
+            // 10,000,000
+            else if (i >= 10000000 && i < 100000000) {
+                ans += 8;
+            }
+            // 100,000,000
+            else {
+                ans += 9;
+            }
+        }
+        System.out.println(ans);
+    }
+}

--- a/jeongwoo/home/2022-03/31/Boj6064.java
+++ b/jeongwoo/home/2022-03/31/Boj6064.java
@@ -1,0 +1,79 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+/**
+ * [6064] 카잉 달력
+ * https://www.acmicpc.net/problem/5064
+ *
+ * -아이디어
+ * 1. N과 M보다 작거나 같은 두 자연수 x, y로 해를 나타낸다
+ * 2. x % N, y % M으로 표현할 수 있음
+ * 3. x, y가 같은 숫자가 될 때까지 years++;
+ * 4. 안 나온다면 -1
+ * --> 시간 초과
+ * 10 12 3 9
+ * 1. x에 맞는 years를 구한다.
+ * 2. 위 테스트 케이스의 경우 x = 3이니까 가능한 years = 3, 13, 23, ... -> years = Ni + x ( i = 1, 2, 3, ...) years < lcm(N, M)까지
+ * 3. 가능한 years에서 y를 구한다. y = years % M
+ *
+ * -시간 복잡도
+ * 1. O(NM)
+ * 2. O(lcm(m, n))
+ *
+ * -자료 구조
+ * 1.
+ */
+
+public class Boj6064 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+        int t = Integer.parseInt(br.readLine());
+        int[][] arr = new int[t][4];
+
+        for (int i = 0; i < t; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < 4; j++) {
+                arr[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+
+        for (int i = 0; i < t; i++) {
+                int m = arr[i][0];
+                int n = arr[i][1];
+                int x = arr[i][2];
+                int y = arr[i][3];
+
+                int years = x;
+                int max = lcm(m, n);
+
+                while (true) {
+                    if (years > max) {
+                        System.out.println("-1");
+                        break;
+                    }
+                    else if (((years % n) == 0 ? n : years % n) == y) {
+                        System.out.println(years);
+                        break;
+                    }
+                    years += m;
+                }
+        }
+
+
+    }
+
+    private static int gcd(int a, int b) {
+        if (b == 0)
+            return a;
+        return gcd(b, a % b);
+
+    }
+
+    private static int lcm(int a, int b) {
+        return (a * b) / gcd(a, b);
+    }
+}


### PR DESCRIPTION
### [6064] 카잉 달력
-아이디어
 1. N과 M보다 작거나 같은 두 자연수 x, y로 해를 나타낸다
 2. x % N, y % M으로 표현할 수 있음
 3. x, y가 같은 숫자가 될 때까지 years++;
 4. 안 나온다면 -1
--> 시간 초과
 10 12 3 9
 1. x에 맞는 years를 구한다.
 2. 위 테스트 케이스의 경우 x = 3이니까 가능한 years = 3, 13, 23, ... -> years = Ni + x ( i = 1, 2, 3, ...) years < lcm(N, M)까지
 3. 가능한 years에서 y를 구한다. y = years % M
 
-시간 복잡도
 1. O(NM)
 2. O(lcm(m, n))

안 될 거 알았지만 일단 MN까지 하는 걸로 접근해 보았다.. x부터 구하고 등차 수열처럼 증가하면서 y를 구하면 더 빠르고, 최댓값을 lcm으로 둬야 한다. lcm은 생각도 못 함.
--
### 1748 수 이어 쓰기 1
-아이디어
 1. n을 입력 받으면 1부터 n까지 숫자 이어 쓰기
 2. 1부터 n까지 숫자를 다 입력 받지 말고 자릿수만 계산하면 된다
 3. n은 최대 1억이니까 일, 십, 백, 천, 만, 십만, 백만, 천만, 억 자릿수 + 십억 하나

문제에서 요구하는 게 자릿수인 만큼 직접 다 써서 구하려고 하지 말고 자릿수로 접근해야 된다