### PR TITLE
Jihoon: Boj 15663 / Boj 15664

### DIFF
--- a/jihoon/home/4-5/Boj_15663.java
+++ b/jihoon/home/4-5/Boj_15663.java
@@ -1,0 +1,59 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Boj_15663 {
+    
+    public static int N;
+    public static int M;
+    public static int[] numbers;
+    public static int[] arr;
+    public static boolean[] visit;
+    public static int count = 0;
+    public static LinkedHashSet<String> set = new LinkedHashSet<>();
+    
+    public static void bfs(int depth) {
+        if (depth == M) {
+            var sb = new StringBuilder();
+            for (int n : arr) {
+                sb.append(n).append(' ');
+            }
+            set.add(sb.toString());
+            return;
+        }
+        
+        for (int i = 0; i < N; i++) {
+            if (!visit[i]) {
+                visit[i] = true;
+                arr[depth] = numbers[i];
+                bfs(depth + 1);
+                visit[i] = false;
+            }
+        }
+    }
+    
+    public static void main(String[] args) throws IOException {
+        var bf = new BufferedReader(new InputStreamReader(System.in));
+        var st = new StringTokenizer(bf.readLine(), " ");
+        var line = new StringTokenizer(bf.readLine(), " ");
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        numbers = new int[N];
+        arr = new int[M];
+        visit = new boolean[N];
+        
+        for (int i = 0; i < N; i++) {
+            int n = Integer.parseInt(line.nextToken());
+            numbers[i] = n;
+        }
+        Arrays.sort(numbers);
+        
+        bfs(0);
+        for (String s : set) {
+            System.out.println(s);
+        }
+        
+        bf.close();
+    }
+}

--- a/jihoon/home/4-5/Boj_15664.java
+++ b/jihoon/home/4-5/Boj_15664.java
@@ -1,0 +1,59 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Boj_15664 {
+    
+    public static int N;
+    public static int M;
+    public static int[] numbers;
+    public static int[] arr;
+    public static boolean[] visit;
+    public static int count = 0;
+    public static LinkedHashSet<String> set = new LinkedHashSet<>();
+    
+    public static void bfs(int at, int depth) {
+        if (depth == M) {
+            var sb = new StringBuilder();
+            for (int n : arr) {
+                sb.append(n).append(' ');
+            }
+            set.add(sb.toString());
+            return;
+        }
+        
+        for (int i = at; i < N; i++) {
+            if (!visit[i]) {
+                visit[i] = true;
+                arr[depth] = numbers[i];
+                bfs(i, depth + 1);
+                visit[i] = false;
+            }
+        }
+    }
+    
+    public static void main(String[] args) throws IOException {
+        var bf = new BufferedReader(new InputStreamReader(System.in));
+        var st = new StringTokenizer(bf.readLine(), " ");
+        var line = new StringTokenizer(bf.readLine(), " ");
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        numbers = new int[N];
+        arr = new int[M];
+        visit = new boolean[N];
+        
+        for (int i = 0; i < N; i++) {
+            int n = Integer.parseInt(line.nextToken());
+            numbers[i] = n;
+        }
+        Arrays.sort(numbers);
+        
+        bfs(0, 0);
+        for (String s : set) {
+            System.out.println(s);
+        }
+        
+        bf.close();
+    }
+}


### PR DESCRIPTION
## Boj 15663
이전 문제에서와 로직은 똑같고 차이점은 1~n까지의 숫자를 고르는 것이 아니라 주어진 배열에서 숫자를 고르는 것이다. numbers을 전역변수 배열로 만들어서 수를 고르게 하였다.

## Boj 15664
이전 문제들과 똑같이 수를 뽑되, 중복된 값만 제거하면 되었다. 처음에 set을 생각했지만 set은 순서가 엉망이 되어버렸기 때문에
List으로 만들어서 List에 넣으면서 contains을 써보았다. 이 문제에서는 시간 초과가 안 났던 것으로 기억하지만 이후 문제에서는 시간초과가 났다. 값을 넣을 때마다 contains메서드로 O(N)만큼 검색을 해야 하니 시간이 오래 걸린 것이다.
set을 이용하면서 순서를 기억할 방법을 찾다가 삽입된 순서를 기억하면서 중복을 제거하는 LinkedHashSet 자료구조가 있다는 점을 알게 되었다.