### PR TITLE
Jihoon: Boj 1759 암호 만들기 / Boj 14501 퇴사 / Boj 14889 스타트와 링크

### DIFF
--- a/jihoon/home/4-9/Boj_14501.java
+++ b/jihoon/home/4-9/Boj_14501.java
@@ -25,7 +25,7 @@ public class Boj_14501 {
                 continue;
             }
             
-            // 현재 뽑으려는 상담일이 퇴사 날짜보다 클 때
+            // 현재 뽑으려는 상담일이 퇴사 날짜보다 클 때 continue
             if (i + map[i][0] > N) {
                 continue;
             }

--- a/jihoon/home/4-9/Boj_14501.java
+++ b/jihoon/home/4-9/Boj_14501.java
@@ -1,0 +1,52 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.StringTokenizer;
+
+public class Boj_14501 {
+    public static int N;
+    public static int[][] map;
+    public static ArrayList<Integer> temp = new ArrayList<>();
+    public static int maxPrice = 0;
+    
+    public static void dfs(int start, int depth) {
+        if (1 <= depth) {
+            int price = 0;
+            for (int i : temp) {
+                price += map[i][1];
+            }
+            maxPrice = Math.max(maxPrice, price);
+        }
+    
+        for (int i = start; i < N; i++) {
+            // 그전에 뽑은 인덱스 번호와 뽑으려는 인덱스 번호의 차이가 상담일보다 작을 때 continue
+            if (depth > 0 && map[temp.get(depth - 1)][0] > i - temp.get(depth - 1)) {
+                continue;
+            }
+            
+            // 현재 뽑으려는 상담일이 퇴사 날짜보다 클 때
+            if (i + map[i][0] > N) {
+                continue;
+            }
+            
+            temp.add(i);
+            dfs(i + 1, depth + 1);
+            temp.remove(temp.size() - 1);
+        }
+    }
+    
+    public static void main(String[] args) throws IOException {
+        var bf = new BufferedReader(new InputStreamReader(System.in));
+        N = Integer.parseInt(bf.readLine());
+        map = new int[N][2];
+        for (int i = 0; i < N; i++) {
+            var st = new StringTokenizer(bf.readLine(), " ");
+            map[i][0] = Integer.parseInt(st.nextToken());
+            map[i][1] = Integer.parseInt(st.nextToken());
+        }
+        bf.close();
+        dfs(0, 0);
+        System.out.println(maxPrice);
+    }
+}

--- a/jihoon/home/4-9/Boj_14889.java
+++ b/jihoon/home/4-9/Boj_14889.java
@@ -1,0 +1,71 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.StringTokenizer;
+
+public class Boj_14889 {
+    public static int N;
+    public static int[] temp;
+    public static int[][] ability;
+    public static int[] teamAbility;
+    public static int min = Integer.MAX_VALUE;
+    public static ArrayList<ArrayList<Integer>> combinations = new ArrayList<>();
+    
+    public static void dfs(int at, int depth) {
+        if (depth == N / 2) {
+            ArrayList<Integer> list = new ArrayList<>();
+            for (int n : temp) {
+                list.add(n);
+            }
+            combinations.add(list);
+            return;
+        }
+    
+        for (int i = at; i < N; i++) {
+            temp[depth] = i;
+            dfs(i + 1, depth + 1);
+        }
+    }
+    
+    public static void calculateAbility() {
+        for (int i = 0; i < combinations.size(); i++) {
+            int sum = 0;
+            for (int j = 0; j < N / 2; j++) {
+                for (int k = j; k < N / 2; k++) {
+                    int index1 = combinations.get(i).get(j);
+                    int index2 = combinations.get(i).get(k);
+                    sum += ability[index1][index2] + ability[index2][index1];
+                }
+            }
+            teamAbility[i] = sum;
+        }
+    }
+    
+    public static void calculateMin() {
+        for (int i = 0; i < teamAbility.length / 2; i++) {
+            int diff = Math.abs(teamAbility[i] - teamAbility[teamAbility.length - 1 - i]);
+            min = Math.min(min, diff);
+        }
+    }
+    
+    public static void main(String[] args) throws IOException {
+        var bf = new BufferedReader(new InputStreamReader(System.in));
+        N = Integer.parseInt(bf.readLine());
+        ability = new int[N][N];
+        temp = new int[N / 2];
+        
+        for (int i = 0; i < N; i++) {
+            var st = new StringTokenizer(bf.readLine(), " ");
+            for (int j = 0; j < N; j++) {
+                ability[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+    
+        dfs(0, 0);
+        teamAbility = new int[combinations.size()];
+        calculateAbility();
+        calculateMin();
+        System.out.println(min);
+    }
+}

--- a/jihoon/home/4-9/Boj_1759.java
+++ b/jihoon/home/4-9/Boj_1759.java
@@ -1,0 +1,66 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.List;
+import java.util.StringTokenizer;
+
+public class Boj_1759 {
+    public static int L;
+    public static int C;
+    public static String[] s;
+    public static String[] arr;
+    public static boolean[] visit;
+    public static StringBuilder sb = new StringBuilder();
+    public static final List<String> vowels = Arrays.asList("a", "e", "i", "o", "u");
+    
+    public static void dfs(int at, int depth) {
+        if (depth == L) {
+            int countVowels = countVowels(arr);
+            if (countVowels > 0 && countVowels <= L - 2) {
+                for (String str : arr) {
+                    sb.append(str);
+                }
+                sb.append("\n");
+            }
+            
+            return;
+        }
+    
+        for (int i = at; i < C; i++) {
+            if (visit[i]) continue;
+            visit[i] = true;
+            arr[depth] = s[i];
+            dfs(i, depth + 1);
+            visit[i] = false;
+        }
+    }
+    
+    public static int countVowels(String[] s) {
+        int count = 0;
+        for (String str : s)
+            if (vowels.contains(str)) count++;
+        
+        return count;
+    }
+    
+    public static void main(String[] args) throws IOException {
+        var bf = new BufferedReader(new InputStreamReader(System.in));
+        var st = new StringTokenizer(bf.readLine(), " ");
+        var line = new StringTokenizer(bf.readLine(), " ");
+        L = Integer.parseInt(st.nextToken());
+        C = Integer.parseInt(st.nextToken());
+        s = new String[C];
+        arr = new String[L];
+        visit = new boolean[C];
+    
+        for (int i = 0; i < C; i++) {
+            s[i] = line.nextToken();
+        }
+        Arrays.sort(s);
+        
+        dfs(0, 0);
+        System.out.println(sb);
+        bf.close();
+    }
+}

--- a/jihoon/home/4-9/Boj_1759.java
+++ b/jihoon/home/4-9/Boj_1759.java
@@ -10,7 +10,6 @@ public class Boj_1759 {
     public static int C;
     public static String[] s;
     public static String[] arr;
-    public static boolean[] visit;
     public static StringBuilder sb = new StringBuilder();
     public static final List<String> vowels = Arrays.asList("a", "e", "i", "o", "u");
     
@@ -23,16 +22,12 @@ public class Boj_1759 {
                 }
                 sb.append("\n");
             }
-            
             return;
         }
     
         for (int i = at; i < C; i++) {
-            if (visit[i]) continue;
-            visit[i] = true;
             arr[depth] = s[i];
-            dfs(i, depth + 1);
-            visit[i] = false;
+            dfs(i + 1, depth + 1);
         }
     }
     
@@ -52,7 +47,6 @@ public class Boj_1759 {
         C = Integer.parseInt(st.nextToken());
         s = new String[C];
         arr = new String[L];
-        visit = new boolean[C];
     
         for (int i = 0; i < C; i++) {
             s[i] = line.nextToken();


### PR DESCRIPTION
## Boj 1759 암호 만들기
![Screen Shot 2022-04-09 at 1 34 39 PM](https://user-images.githubusercontent.com/23613481/162556473-df4399a9-4d3a-4b82-b1b2-fd2bd9928106.png)

조합으로 가능한 모든 암호들을 만든다음 모음의 개수를 세도록 했다. 모음이 하나도 없거나 L-2보다 많이 나온 경우(자음이 2개 미만으로 나온 경우)를 제외하도록 했다.

## Boj 14501 퇴사
![Screen Shot 2022-04-09 at 1 34 17 PM](https://user-images.githubusercontent.com/23613481/162556458-6f007b97-6451-46bb-a169-70b7dbe6fa03.png)

주석으로 보시라


## Boj 14889 스타트와 링크
![Screen Shot 2022-04-09 at 1 33 31 PM](https://user-images.githubusercontent.com/23613481/162556425-7dfa2237-a4a9-4579-b205-39cb5a3c022c.png)

depth == N / 2일때 모든 경우를 구한다음 그 배열의 절반만큼 루프를 돌며 서로 대칭을 이루는 팀을 스타트 팀과 링크팀으로 구분하였다.
예를 들면 1, 2, 3, 4가 나온 경우 4C2의 조합의 경우는,
1, 2
1, 3
1, 4
2, 3
2, 4
3, 4
여기서 (1, 2) <-> (3, 4), (1, 3) <-> (2, 4), (1, 4) <-> (2, 3)이 각각 스타트와 링크 팀이 되는 경우다.
각 팀마다 이중루프를 돌면서 팀의 능력치를 더한다음 최소치를 구했다.