### PR TITLE
Jungmin : Boj 1759 / Boj 14501 / Boj 14889

### DIFF
--- a/chris-an/home/4.09/Boj_14501.java
+++ b/chris-an/home/4.09/Boj_14501.java
@@ -1,0 +1,45 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Boj_14501 {
+
+    static int N;
+    static int[] T;
+    static int[] P;
+    static int retirementDday;
+    static int max;
+
+    static void dfs(int day, int sumMoney) {
+        if (day == N) {
+            max = Math.max(max, sumMoney);
+            return;
+        }
+
+        dfs(day + 1, sumMoney); // 퇴사 직전 일자 세팅
+
+        if (retirementDday > day + T[day]) { // 위 루프를 돈 상태에서, 퇴사 직전일부터 1일까지 상담일자 +, 상담금액 +
+            dfs(day + T[day], sumMoney + P[day]);
+        }
+
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        N = Integer.parseInt(br.readLine());
+        retirementDday = N + 1;
+        T = new int[N];
+        P = new int[N];
+
+        for (int i = 0; i < N; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            T[i] = Integer.parseInt(st.nextToken());
+            P[i] = Integer.parseInt(st.nextToken());
+        }
+
+        dfs(0, 0);
+
+        System.out.println(max);
+    }
+}

--- a/chris-an/home/4.09/Boj_14889.java
+++ b/chris-an/home/4.09/Boj_14889.java
@@ -1,0 +1,93 @@
+import java.io.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+public class Boj_14889 {
+
+    static int N;
+    static boolean[] visited;
+    static int[] arrTemp;
+    static int[][] inputDataArr;
+
+    static List<ArrayList<Integer>> twoTeamStatsList = new ArrayList<>();
+    static int composeTeam;
+
+    static int min = Integer.MAX_VALUE;
+    static int sum;
+
+    static void backtracking(int start, int depth) {
+        if (depth == N/2) {
+            ArrayList<Integer> list = new ArrayList<>();
+            for (int i : arrTemp) {
+                list.add(i);
+            }
+            twoTeamStatsList.add(list);
+            return;
+        }
+
+        for (int i = start; i < N; i++) {
+            if (!visited[i]) {
+                visited[i] = true;
+                arrTemp[depth] = i + 1;
+                backtracking(i + 1, depth+1);
+                visited[i] = false;
+            }
+        }
+    }
+
+    static void teamStatsRoof(List<Integer> list, int idx, int depth) {
+        if (depth == 2) {
+            sum +=  inputDataArr[arrTemp[0]-1][arrTemp[1]-1];
+            return;
+        }
+
+        for (int i = 0; i < list.size(); i++) {
+            if (!visited[i]) {
+                visited[i] = true;
+                arrTemp[depth] = twoTeamStatsList.get(idx).get(i);
+                teamStatsRoof(list, idx,depth + 1);
+                visited[i] = false;
+            }
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        N = Integer.parseInt(br.readLine());
+
+        inputDataArr = new int[N][N];
+
+        for (int i = 0; i < N; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < N; j++) {
+                inputDataArr[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        arrTemp = new int[N/2];
+        visited = new boolean[N];
+
+        backtracking(0, 0);
+
+        List<Integer> temp = new ArrayList<>();
+        for (int i = 0; i < twoTeamStatsList.size(); i++) {
+            sum = 0;
+            visited = new boolean[twoTeamStatsList.get(0).size()];
+            arrTemp = new int[2];
+            teamStatsRoof(twoTeamStatsList.get(i), i, 0);
+            temp.add(sum);
+        }
+
+        composeTeam = twoTeamStatsList.size() / 2; // 절반 루프
+        for (int i =0; i < composeTeam; i++) {
+            int startTeam = temp.get(i);
+            int linkTeam = temp.get(twoTeamStatsList.size() - 1 - i);
+
+            min = Math.min(min, Math.abs(startTeam - linkTeam));
+        }
+
+        System.out.println(min);
+    }
+}

--- a/chris-an/home/4.09/Boj_1759.java
+++ b/chris-an/home/4.09/Boj_1759.java
@@ -1,0 +1,64 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Boj_1759 {
+    static int L,C;
+    static boolean[] visited;
+    static StringBuilder sb = new StringBuilder();
+    static String[] arr;
+    static String[] inputDataArr;
+    static final String vowels = "aeiou";
+    static int vowelCnt, consonant;
+
+    public static void backTracking(int start, int depth) {
+
+        if (depth == L) {
+            vowelCnt = 0;
+            consonant = 0;
+            for (String s : arr) {
+                if (vowels.contains(s)) vowelCnt++;
+                else consonant++;
+            }
+
+
+            if (vowelCnt > 0 && consonant > 1) {
+                for (String s : arr) {
+                    sb.append(s);
+                }
+                sb.append('\n');
+            }
+            return;
+        }
+
+        for (int i = start; i < C; i++) {
+            if (!visited[i]) {
+                visited[i] = true;
+                arr[depth] = inputDataArr[i];
+                backTracking(i + 1,depth + 1);
+                visited[i] = false;
+            }
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        L = Integer.parseInt(st.nextToken());
+        C = Integer.parseInt(st.nextToken());
+        arr = new String[L];
+        inputDataArr = new String[C];
+        visited = new boolean[C];
+        st = new StringTokenizer(br.readLine()); // C의 전체 암호를 받습니다.
+        for (int i = 0; i < C; i++) {
+            inputDataArr[i] = st.nextToken();
+        }
+
+        Arrays.sort(inputDataArr);
+
+        backTracking(0,0);
+        System.out.println(sb);
+    }
+}


### PR DESCRIPTION
### 1️⃣ 암호만들기 (1759)
알파벳이 암호에서 증가하는 순서의 배열이고 두 가지 조건을 만족시키기 위해서 방문처리로 dfs 로직으로 증가하는 배열 중, 조건으로 걸러주었습니다. 전에 풀었던 문제와 유사해 금방 접근할 수 있었습니다.

---
### 2️⃣ 퇴사 (14501)
문제 풀 때, 로직 설계는 잘 된 거 같은데 구현하는 게 힘들었습니다...
재귀에 이해도가 많이 부족했던 거 같습니다. 
이번 문제를 통해서 재귀함수 구현하는 사고 유연성이 좀 넓혀진 거 같습니다.

---
### 3️⃣ 스타트와 링크
풀었지만, 너무 주먹 구구식으로 문제를 접근해서 푼 느낌입니다.
1 - 두 팀 전체의 팀원을 만들 수 있는 리스트를 만듭니다. `1 ~ 중간 (스타트)`,  `중간 ~ 끝 (링크)`
2 - 능력치 조합을 통해 더해줍니다.
3 - 두 팀 능력 차이를 비교해주고, 최소 차이를 찾습니다.

---