### PR TITLE
yoonji: boj 11721 연결요소의 개수 / 1707 이분 그래프

### DIFF
--- a/yoonji/home/4/13/boj_1260.java
+++ b/yoonji/home/4/13/boj_1260.java
@@ -1,0 +1,83 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+// DFS와 BFS
+// 깊이 우선 탐색. 인접한 노드들의 가장 깊이 연결된 노드까지 탐색하여 돌아오는 방식
+// 너비 우선 탐색 : 가장 인접한 노드들을 먼저 방문한 뒤, 그 노드들의 인접 노드들을 방문하는 것을 반복하는 방식
+public class boj_1260{
+    static boolean[] visited;
+    static StringBuilder sb = new StringBuilder();
+    static int nodeNum, startNode;
+    public static void main(String[] args) throws IOException {
+        // 1. 입력받고 인접 리스트 생성
+        input();
+        // 2. dfs 수행
+        visited = new boolean[nodeNum+1];
+        dfs_recursion(startNode);
+        System.out.println(sb); sb.setLength(0);
+        // 3.  bfs 수행
+        visited = new boolean[nodeNum+1];  // 초기화
+        bfs(startNode);
+        System.out.println(sb);
+    }
+
+    static BufferedReader br;
+    static LinkedList<Integer>[] adj;
+    private static void input() throws IOException {
+        br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        nodeNum = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+        startNode = Integer.parseInt(st.nextToken());
+
+        // 각 배열의 리스트 초기화 (노드는 1부터 시작)
+        adj = new LinkedList[nodeNum+1];  // 최대 N개 크기
+        for (int i=1; i<nodeNum+1; i++) {
+            adj[i] = new LinkedList<>();
+        }
+        makeAdjGraph(M);
+    }
+    private static void makeAdjGraph(int edgeLen) throws IOException {
+        for (int i=0; i<edgeLen; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            int nodeA = Integer.parseInt(st.nextToken());
+            int nodeB = Integer.parseInt(st.nextToken());
+            // 양방향
+            adj[nodeA].add(nodeB);
+            adj[nodeB].add(nodeA);
+        }
+        for (int i=1; i<nodeNum+1; i++) {
+            // 크기 오름차순으로 sort
+            Collections.sort(adj[i]);
+        }
+    }
+
+    private static void dfs_recursion(int node) {
+        visited[node] = true;
+        sb.append(node).append(" ");
+        Iterator<Integer> listIter = adj[node].listIterator();//LinkedList에 대한 iterator 생성
+        while (listIter.hasNext()){
+            int linkedNode = listIter.next();
+            if (!visited[linkedNode]) {
+                dfs_recursion(linkedNode);  // 리스트를 static으로 둘수있으면 좋을텐데
+            }
+        }
+    }
+    private static void bfs(int startNode) {
+        Queue<Integer> q = new LinkedList<>();        // 정점에 연결된 노드들을 먼저 방문하므로 큐
+        q.add(startNode);
+        visited[startNode] = true;
+        while (!q.isEmpty()) {
+            int node = q.poll();
+            sb.append(node).append(" ");    // 방문이자 출력
+            for (int i=0; i< adj[node].size(); i++) {
+                int tmp = adj[node].get(i);
+                if (!visited[tmp]) {
+                    visited[tmp] = true;
+                    q.add(tmp);     // 방문한 노드의 인접노드들을 탐색하기 위해 큐에 추가
+                }
+            }
+        }
+    }
+}

--- a/yoonji/home/4/13/boj_13023.java
+++ b/yoonji/home/4/13/boj_13023.java
@@ -1,7 +1,7 @@
 import java.util.*;
 import java.io.*;
-// 종이 조각
-public class boj_14391 {
+// ABCDE
+public class boj_13023 {
     static boolean[] visited;
     static int N;
     static List<Integer>[] adj;

--- a/yoonji/home/4/13/boj_14391.java
+++ b/yoonji/home/4/13/boj_14391.java
@@ -1,0 +1,45 @@
+import java.util.*;
+import java.io.*;
+// 종이 조각
+public class boj_14391 {
+    static boolean[] visited;
+    static int N;
+    static List<Integer>[] adj;
+    public static void main(String[] args) throws IOException {
+        // input & 초기화
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+        N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+        adj = new ArrayList[N];
+        for (int i = 0; i < N; i++) adj[i] = new ArrayList<>(); // add 하기 전 초기화
+        while (M-- > 0) {
+            st = new StringTokenizer(br.readLine(), " ");
+            int row = Integer.parseInt(st.nextToken());
+            int col = Integer.parseInt(st.nextToken());
+            adj[row].add(col);
+            adj[col].add(row);
+        }
+        // 시작 노드 모두 탐색해야함
+        for (int startNode=0; startNode<N; startNode++) {
+            visited = new boolean[N];
+            dfs(0, startNode);    // 깊이와 시작 노드
+        }
+        System.out.println(0);
+    }
+    static void dfs(int depth, int node) {
+        if (depth == 4) {   // 깊이 4라는 것은 친구 5명이 연결된 것.
+            System.out.println(1);
+            System.exit(0);
+        }
+        visited[node] = true;
+        for (int i=0; i< adj[node].size(); i++) {   // 해당 노드의 연결된 노드까지만 탐색
+            int adjNode = adj[node].get(i);
+            if (!visited[adjNode]) {
+                visited[adjNode] = true;
+                dfs(depth+1, adjNode);    // 연결된 친구일 때의 깊이++
+                visited[adjNode] = false;
+            }
+        }
+    }
+}

--- a/yoonji/home/4/14/boj_11724.java
+++ b/yoonji/home/4/14/boj_11724.java
@@ -1,0 +1,2 @@
+package PACKAGE_NAME;public class boj_11724 {
+}

--- a/yoonji/home/4/14/boj_11724.java
+++ b/yoonji/home/4/14/boj_11724.java
@@ -1,2 +1,50 @@
-package PACKAGE_NAME;public class boj_11724 {
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+// 연결 요소의 개수
+public class boj_11724 {
+    static List<Integer>[] adj;
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    public static void main(String[] args) throws IOException {
+        input();
+        int connectionCnt=0;
+        boolean[] visited = new boolean[N+1];
+        for (int i=1; i<N+1; i++) {
+            if (!visited[i]) {
+                Queue<Integer> que = new LinkedList<>();
+                que.add(i); visited[i] = true;
+                while(!que.isEmpty()) {
+                    Integer node = que.poll();
+                    for (int j=0; j<adj[node].size(); j++) {
+                        Integer adjNode = adj[node].get(j);
+                        if (!visited[adjNode])
+                            que.add(adjNode); visited[adjNode] = true;
+                    }
+                }
+                connectionCnt++;
+            }
+        }
+        System.out.println(connectionCnt);
+    }
+    static int N;
+    private static void input() throws IOException {
+        StringTokenizer st = new StringTokenizer(br.readLine()," ");
+        N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+        makeAdjGraph(N, M);
+    }
+    private static void makeAdjGraph(int nodeN, int edgeN) throws IOException {
+        adj = new LinkedList[nodeN+1];
+        for (int i = 1; i < nodeN+1; i++) adj[i] = new LinkedList<>();
+        StringTokenizer st;
+        for (int i=0; i< edgeN; i++) {
+            st = new StringTokenizer(br.readLine()," ");
+            int nodeA = Integer.parseInt(st.nextToken());
+            int nodeB = Integer.parseInt(st.nextToken());
+            adj[nodeA].add(nodeB);
+            adj[nodeB].add(nodeA);
+        }
+    }
 }

--- a/yoonji/home/4/14/boj_1707.java
+++ b/yoonji/home/4/14/boj_1707.java
@@ -1,0 +1,66 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+// 이분 그래프
+// 두 그룹으로 분할했을 시, 각 그룹 내에서 인접하면 안된다.
+public class boj_1707 {
+    static List<Integer>[] adj;
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static final int CHECKER = 1;    // 인접노드끼리는 다른 값을 갖는다. (1과 -1)
+    public static void main(String[] args) throws IOException {
+        StringTokenizer st = new StringTokenizer(br.readLine()," ");
+        int testCase = Integer.parseInt(st.nextToken());
+        StringBuilder answer = new StringBuilder();
+        while (testCase-- > 0) {
+            st = new StringTokenizer(br.readLine()," ");
+            int N = Integer.parseInt(st.nextToken());
+            int M = Integer.parseInt(st.nextToken());
+            makeAdjGraph(N, M);
+            answer.append(checkBipartiteGraph(N)).append("\n");
+        }
+        System.out.println(answer);
+    }
+
+    private static String checkBipartiteGraph(int nodeN) {
+        boolean[] visited = new boolean[nodeN+1];
+        int[] checkAdj = new int[nodeN+1];
+        for (int i=1; i<nodeN+1; i++) {
+            if (!visited[i]) {
+                Queue<Integer> que = new LinkedList<>();
+                que.add(i); visited[i] = true;
+                checkAdj[i] = CHECKER;
+                while(!que.isEmpty()) {
+                    Integer node = que.poll();
+                    for (int adjNode: adj[node]) {    // 인접 노드들 탐색
+                        if (!visited[adjNode]) {
+                            que.add(adjNode); visited[adjNode] = true;  // 연결
+                            checkAdj[adjNode] = checkAdj[node] * (-1);  //
+                        } else {    // 이미 방문한 노드인 경우
+                            if (checkAdj[node] == checkAdj[adjNode]) {
+                                return "NO";
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return "YES";
+    }
+    private static void makeAdjGraph(int nodeN, int edgeN) throws IOException {
+        adj = new LinkedList[nodeN+1];
+        for (int i = 1; i < nodeN+1; i++) adj[i] = new LinkedList<>();
+        StringTokenizer st;
+        for (int i=0; i< edgeN; i++) {
+            st = new StringTokenizer(br.readLine()," ");
+            int nodeA = Integer.parseInt(st.nextToken());
+            int nodeB = Integer.parseInt(st.nextToken());
+            adj[nodeA].add(nodeB);
+            adj[nodeB].add(nodeA);
+        }
+    }
+}


### PR DESCRIPTION
## 11721 연결요소의 개수
### 설계
- 연결된 노드들에 한해서 큐가 채워지고 비워지기 때문에, 이를 기준으로 연결 요소 갯수를 ++합니다.

## 1707 이분 그래프
### 설계
- 이분 그래프는 두 그룹으로 분할했을 시, 각 그룹 내에서 인접하면 안된다.
- 그래프 상 각 layer간 인접하면 안되므로, CHECKER를 이용해서 구분한다.
- 인접 노드 간 같은 CHECKER라면 이분 그래프가 성립되지 않는다.
### 후기
- 이분 그래프 개념에 대해 다시 알게 되었습니다.

> 두 문제 모두 bfs로 풀었습니다.
