### PR TITLE
Jungmin : Boj 7576 / Boj 7562 / Boj 16929

### DIFF
--- a/chris-an/home/4.16/Boj_16929.java
+++ b/chris-an/home/4.16/Boj_16929.java
@@ -1,0 +1,67 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Boj_16929 {
+    /*
+        Two Dots
+        사이클을 찾는 문제, 즉 처음시작한 점과, 마지막으로 끝나는 점이 만나서 서클을 이룬다 생각
+     */
+
+    static int N, M; // 세로, 가로
+    static String[][] map;
+    static boolean[][] visited;
+    static int[] dx = {0, -1, 0, 1};
+    static int[] dy = {-1, 0, 1, 0};
+    static boolean flag;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken()); // 세로
+        M = Integer.parseInt(st.nextToken()); // 가로
+
+        map = new String[N][M];
+        for (int i = 0; i < N; i++) {
+            String[] line = br.readLine().split("");
+            for (int j = 0; j < M; j++) {
+                map[i][j] = line[j];
+            }
+        }
+
+
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < M; j++) {
+                visited = new boolean[N][M];
+                int cnt = 0;
+                dfs(i, j, cnt, i, j); // (유동시킬 X, 유동시킬 Y, 4개 이상을 위한 cnt, 탐색시작점[고정] X, 탐색시작점[고정] Y)
+                if (flag) break;
+            }
+            if (flag) break;
+        }
+        System.out.println(flag ? "Yes" : "No");
+    }
+
+    private static void dfs(int x, int y, int cnt, int startX, int startY) {
+        if (flag) return;
+        visited[x][y] = true;
+        cnt++;
+        for (int i = 0; i < 4; i++) {
+            int newX = x + dx[i];
+            int newY = y + dy[i];
+
+            if (newX == startX && newY == startY && cnt >= 4) {
+                flag = true;
+                return;
+            }
+
+            if (newX >= 0 && newX < N && newY >= 0 && newY < M
+                    && !visited[newX][newY]
+                    && map[newX][newY].equals(map[startX][startY])) {
+                dfs(newX, newY, cnt, startX, startY);
+            }
+        }
+    }
+}

--- a/chris-an/home/4.16/Boj_7562.java
+++ b/chris-an/home/4.16/Boj_7562.java
@@ -1,0 +1,77 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+class Coordinate__ {
+    int x, y;
+    Coordinate__(int x, int y) {
+        this.x = x;
+        this.y = y;
+    }
+}
+
+public class Boj_7562 {
+
+    static int I;
+    static int x, y; // 초기 좌표
+    static int targetX, targetY; // 찾는 좌표
+    static boolean[][] visited; // 방문처리
+    static int[] dx = {-2, -1, 1, 2, 2, 1, -1, -2};
+    static int[] dy = {-1, -2, -2, -1, 1, 2, 2, 1};
+    static int[][] map;
+    //    static ArrayList<Integer> finishList = new ArrayList<>();
+    static Queue<Coordinate__> qu;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int testCase = Integer.parseInt(br.readLine());
+
+        while (testCase-- > 0) {
+            I = Integer.parseInt(br.readLine());
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            x = Integer.parseInt(st.nextToken());
+            y = Integer.parseInt(st.nextToken());
+
+            st = new StringTokenizer(br.readLine());
+            targetX = Integer.parseInt(st.nextToken());
+            targetY = Integer.parseInt(st.nextToken());
+
+
+            map = new int[I][I];
+            visited = new boolean[I][I];
+            visited[x][y] = true;
+
+
+            qu = new LinkedList<>();
+            qu.offer(new Coordinate__(x, y));
+
+            if (!(x == targetX && y == targetY)) bfs();
+            System.out.println(map[targetX][targetY]);
+
+
+//            Collections.sort(finishList);
+//            System.out.println(finishList.get(0));
+//            System.out.println(finishList.get(finishList.size())-1);
+        }
+    }
+    private static void bfs() {
+        while (!qu.isEmpty()) {
+            Coordinate__ point = qu.poll();
+
+            for (int i = 0; i < 8; i++) {
+                int newX = point.x + dx[i];
+                int newY = point.y + dy[i];
+
+                if (newX >= 0 && newX < I && newY >= 0 && newY < I && !visited[newX][newY]) {
+                    visited[newX][newY] = true;
+                    qu.offer(new Coordinate__(newX, newY));
+                    map[newX][newY] = map[point.x][point.y] + 1;
+
+//                    if (newX == targetX && newY == targetY)
+//                        finishList.add(map[newX][newY]);
+                }
+            }
+        }
+    }
+}

--- a/chris-an/home/4.16/Boj_7576.java
+++ b/chris-an/home/4.16/Boj_7576.java
@@ -1,0 +1,96 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+
+/*
+    1000 x 1000
+    맵에 있는 토마토가 최대 100만 개.. 초단위로 100만번씩 돌면 굉장히 비효율적...음
+
+    정수 1은 익은 토마토,
+    정수 0은 익지 않은 토마토,
+    정수 -1은 토마토가 들어있지 않은 칸을 나타낸다.
+ */
+
+class Coordinate {
+    int x, y;
+    Coordinate(int x, int y) {
+        this.x = x;
+        this.y = y;
+    }
+}
+
+public class Boj_7576 {
+
+    /*
+        토마토
+     */
+    static int N, M;
+    static int[][] map;
+    static int[] dx = {0, 0, 1, -1}; // 동 서 남 북
+    static int[] dy = {1, -1, 0, 0};
+    static int day;
+    static Queue<Coordinate> qu = new LinkedList<>();
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        M = Integer.parseInt(st.nextToken()); // 가로 M
+        N = Integer.parseInt(st.nextToken()); // 세로 N
+
+        // map 선언 및 초기화 (세팅)
+        map = new int[N][M];
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < M; j++) {
+                map[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < M; j++) {
+                if (map[i][j] == 1) {
+                    qu.offer(new Coordinate(i, j)); // 미리 토마토가 있는 곳(좌표값)을 qu 에 담아 놓는다.
+                }
+            }
+        }
+        bfs();
+        System.out.println(day);
+    }
+
+    private static void bfs() {
+        while (!qu.isEmpty()) {
+            Coordinate point = qu.poll();
+
+            for (int i = 0; i < 4; i++) {
+                int newX = point.x + dx[i];
+                int newY = point.y + dy[i];
+                if (newX >= 0 && newX < N && newY >= 0 && newY < M && map[newX][newY] == 0) {
+                    qu.offer(new Coordinate(newX, newY));
+                    map[newX][newY] = map[point.x][point.y] + 1;
+                }
+            }
+        }
+
+        int max = Integer.MIN_VALUE;
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < M; j++) {
+                max = Math.max(max, map[i][j]);
+            }
+        }
+
+        day = max - 1;
+
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < M; j++) {
+                if (map[i][j] == 0) {
+                    day = -1;
+                    break;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### 1️⃣ 토마토
앞에서 문제를 풀었던 거에서 살짝 변형해주면 되는 문제였습니다. 처음에는 매초마다 계속 루프를 돌리면서 시간 초를 누적 시키려고했는데,
복잡도가 굉장히 높아질 거 같다는 생각에 잘못된 접근인 걸 알았습니다.
그래서 qu에 익은 토마토의 좌표를 다 넣은  뒤, 최소시간을 구하는 방법으로 접근방식을 바꿔서 풀었습니다.

---
### 2️⃣ 나이트의 이동
앞에서 풀었던 토마토 문제랑 비슷해서 쉽게 접근을 했지만, 
잘못된 접근을 했는데, 처음 생각에는 문제에서 최소의 이동 횟수를 구한다는 말에, target x,y 까지 갈 수 있는 이동 횟수가 여러 방법이라 생각을 해서 리스트에 이동 값을 다 넣어서 최소값을 구하려 했습니다. 그런데, 무한 루프를 돌았습니다.
그 이후에, 방문처리로 로직을 바꿔서 방문했던 곳은 가지 않도록 하고 bfs 를 돌려서, qu가 다 비었을 때 타겟좌표의 이동값을 뽑는 로직으로 변경했습니다.
> 의문이였던 건, 타겟좌표에는 무조건 도달하고 딱 한 가지 나온 값이 최소 값인가? 였습니다 그런데 검색하다보니 BFS 탐색은 모든 인접 정점을 최소 이동 횟수로 보장해주는 탐색 방식이며. 현재 정점 위치를 저장하고, 그 위치에서 8개의 방향으로 이동하며 목표 지점을 찾을 때까지 탐색을 수행하면 된다는 글을 보고 의문이 였던 점을 접기로 하였습니다.

---
### 3️⃣  Two Dots
처음 접근은 bfs 푸는 것처럼 좌표클래스를 만들어 Stack 을 이용하여 dfs 깊이 탐색을 시키다가, 첫 출발한 좌표값을 만나면 멈추는 식으로 만드는 방법으로 접근했습니다. 그런데 첫출발 그 1단계 이후에 방문처리 true로 되어, 마지막 부분에서 첫 촤표값을 만나지 못해서 로직 마무리가 안됐습니다. 그래서 첫 출발 좌표 1단계 뒤에는 방문처리를 false로 설정하여 로직을 변경하여서 구현한다면, 구현까지는 가능할 거 같았습니다.
그런데 첫 접근 생각에 막혀 이후, 막힌 부분을 무작정 뚫기 보단  접근자체 의심을 한 뒤에 다시 설계를 했습니다.  매번 방문처리 기록을 초기화해서 n*m루프를 돌아 dfs 방문처리 재귀 방식으로 바꿔서 circle이 있을 시, 모든 프로세스 retrun 시키는 방법으로 구현했습니다.

> bfs 에 적응되니, dfs 가 버벅이네요.. 참