### PR TITLE
yoonji: boj 1991 트리순회 / 1261  알고스팟

### DIFF
--- a/yoonji/home/4/21/boj_1261.java
+++ b/yoonji/home/4/21/boj_1261.java
@@ -1,0 +1,63 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.StringTokenizer;
+
+// 알고스팟
+// 상하좌우 이동 가능
+// 돌아가야하는 경우에도 벽보다는 방으로 간다.
+// 1보다 0으로 가는 것을 우선순위로 둔다. -> 0-1 BFS
+public class boj_1261 {
+    static int[] dx = {-1, 1, 0, 0};
+    static int[] dy = {0, 0, -1, 1};
+    static int[][] map;
+    static int N,M;
+    public static void main(String[] args) throws IOException {
+        // 1. 초기화 및 그래프(2차원 행렬) 생성
+        input();
+        // 2. 0-1 BFS (Queue 이용)
+        // 상하좌우로 가는데, 0으로 가는 로직을 우선순위로 둔다.
+        escapeMaze_bfs();
+    }
+
+    private static void input() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine(),  " ");
+        M = Integer.parseInt(st.nextToken());
+        N = Integer.parseInt(st.nextToken());
+        map = new int[N][M];
+        for (int i=0; i<N; i++) {
+            String str = br.readLine();
+            for (int j=0; j<M; j++) {
+                map[i][j] = Character.getNumericValue(str.charAt(j));   // char => int
+            }
+        }
+    }
+    private static void escapeMaze_bfs() {
+        LinkedList<int[]> que = new LinkedList<>(); // 데이터가 배열인 큐
+        que.offer(new int[]{0, 0, 0});  // x, y, 데이터
+        map[0][0] = -1; // 방문처리
+        while (!que.isEmpty()) {
+            int[] adj = que.poll();
+            int nowX = adj[0];
+            int nowY = adj[1];
+            int crushCnt = adj[2];
+            // 중지 조건 (N,M 만나면 중지)
+            if (nowX == map.length - 1 && nowY == map[0].length - 1) {
+                System.out.println(crushCnt);
+                return;
+            }
+            for (int i = 0; i < dx.length; i++) {
+                int nextX = nowX + dx[i];
+                int nextY = nowY + dy[i];
+                if (nextX < 0 || nextX >= N || nextY < 0 || nextY >= M) continue;
+                // 0으로 가는 경우 : 우선순위 높은 경우를 리스트의 맨 앞에 넣어줌 => 빨리 진행 O
+                if (map[nextX][nextY] == 0) que.addFirst(new int[]{nextX, nextY, crushCnt});
+                // 1으로 가는 경우 : 벽 부수기++
+                else if (map[nextX][nextY] == 1) que.offer(new int[]{nextX, nextY, crushCnt+1});
+                map[nextX][nextY] = -1; // 방문처리
+            }
+        }
+    }
+}

--- a/yoonji/home/4/21/boj_1991.java
+++ b/yoonji/home/4/21/boj_1991.java
@@ -27,39 +27,39 @@ public class boj_1991 {
             tree[node].add(new Node(input[1].charAt(0)-64, input[2].charAt(0)-64));
         }
         // 2. 전위, 중위, 후위 순회
-        before_search(1); sb.append("\n");
-        mid_search(1); sb.append("\n");
-        after_search(1); sb.append("\n");
+        beforeSearch(1); sb.append("\n");
+        midSearch(1); sb.append("\n");
+        afterSearch(1); sb.append("\n");
         System.out.println(sb);
     }
     // 후위 탐색
-    private static void after_search(int nodeIdx) {
+    private static void afterSearch(int nodeIdx) {
         for (Node sub : tree[nodeIdx]) {
             int l = sub.left;
             int r = sub.right;
-            if (l != -18) after_search(l);// 왼쪽 탐색
-            if (r != -18) after_search(r);// 오른쪽 탐색
+            if (l != -18) afterSearch(l);// 왼쪽 탐색
+            if (r != -18) afterSearch(r);// 오른쪽 탐색
             sb.append((char) (nodeIdx + 64));
         }
     }
     // 중위 탐색
-    private static void mid_search(int nodeIdx) {
+    private static void midSearch(int nodeIdx) {
         for (Node sub : tree[nodeIdx]) {
             int l = sub.left;
             int r = sub.right;
-            if (l != -18) mid_search(l);// 왼쪽 탐색
+            if (l != -18) midSearch(l);// 왼쪽 탐색
             sb.append((char) (nodeIdx + 64));
-            if (r != -18) mid_search(r);// 오른쪽 탐색
+            if (r != -18) midSearch(r);// 오른쪽 탐색
         }
     }
     // 전위 탐색
-    static void before_search(int nodeIdx) {
+    static void beforeSearch(int nodeIdx) {
         for (Node sub : tree[nodeIdx]) {
             int l = sub.left;
             int r = sub.right;
             sb.append((char) (nodeIdx + 64));// 먼저 탐색
-            if (l != -18) before_search(l);// 왼쪽 탐색
-            if (r != -18) before_search(r);// 오른쪽 탐색
+            if (l != -18) beforeSearch(l);// 왼쪽 탐색
+            if (r != -18) beforeSearch(r);// 오른쪽 탐색
         }
     }
 }

--- a/yoonji/home/4/21/boj_1991.java
+++ b/yoonji/home/4/21/boj_1991.java
@@ -1,0 +1,65 @@
+import java.util.*;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.IOException;
+// A~G(65~71) 대신 숫자(1~7)로 관리하고 마지막에 +64하여 알파벳으로 출력
+public class boj_1991 {
+    static StringBuilder sb = new StringBuilder();
+    static List<Node>[] tree;
+    private static class Node {
+        int left;
+        int right;
+        public Node(int l, int r) {
+            this.left = l;
+            this.right = r;
+        }
+    }
+    public static void main(String[] args) throws IOException {
+        // 1. 초기화
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int N = Integer.parseInt(br.readLine());
+        tree = new List[N+1];
+        for (int i = 1; i <= N; i++) tree[i] = new ArrayList<>();
+        StringTokenizer st;
+        while (N-- > 0) {
+            String[] input = br.readLine().split(" ");
+            int node = input[0].charAt(0)-64;
+            tree[node].add(new Node(input[1].charAt(0)-64, input[2].charAt(0)-64));
+        }
+        // 2. 전위, 중위, 후위 순회
+        before_search(1); sb.append("\n");
+        mid_search(1); sb.append("\n");
+        after_search(1); sb.append("\n");
+        System.out.println(sb);
+    }
+    // 후위 탐색
+    private static void after_search(int nodeIdx) {
+        for (Node sub : tree[nodeIdx]) {
+            int l = sub.left;
+            int r = sub.right;
+            if (l != -18) after_search(l);// 왼쪽 탐색
+            if (r != -18) after_search(r);// 오른쪽 탐색
+            sb.append((char) (nodeIdx + 64));
+        }
+    }
+    // 중위 탐색
+    private static void mid_search(int nodeIdx) {
+        for (Node sub : tree[nodeIdx]) {
+            int l = sub.left;
+            int r = sub.right;
+            if (l != -18) mid_search(l);// 왼쪽 탐색
+            sb.append((char) (nodeIdx + 64));
+            if (r != -18) mid_search(r);// 오른쪽 탐색
+        }
+    }
+    // 전위 탐색
+    static void before_search(int nodeIdx) {
+        for (Node sub : tree[nodeIdx]) {
+            int l = sub.left;
+            int r = sub.right;
+            sb.append((char) (nodeIdx + 64));// 먼저 탐색
+            if (l != -18) before_search(l);// 왼쪽 탐색
+            if (r != -18) before_search(r);// 오른쪽 탐색
+        }
+    }
+}


### PR DESCRIPTION
## 1991 트리순회 
### 설계
- 로직 처리 중에는 문자를 숫자로 처리하고, 다시 정답을 반환 시에는 문자로 바꿔주었다. (`-64`, `+64`)
### 후기
- `.`인 노드를 처음에 제거하거나 Null을 넣는 식으로 하려했는데, 그냥 방문할 때 조건 처리를 해주는게 더 간단한 것 같다.
- 후위, 중위, 전위 탐색에 대해 코드로 접근해본 적이 있어서 중점 로직 구현은 어렵지 않았다.

## 1261  알고스팟
### 설계
> 주석으로 추가했습니다.
### 부족했던 점
- 방문했던 방에 대해 다시 방문할 수 있는 경우를 제외해줄 생각을 못했다. => 0과 1로 구성된 map 행렬의 값을 -1로 넣어주어 방문 처리를 한다.
### 새로 알게된 점
- `0-1 BFS 알고리즘` (가중치가 0, 1로 주어진 그래프에서 최단경로를 찾아낼 수 있는 알고리즘) 개념을 알게되었다.
   - 먼저 고려해주면 더 빨리 정답을 찾을 수 있는 경우를 **높은 우선순위**로 두어 로직을 처리하는 방법이다.
- `LinkedList` 타입을 `int`타입 배열로 지정할 수 있는 점