### PR TITLE
Jungmin : Boj 1167 / Boj 11725 / Boj 2250(~ing)

### DIFF
--- a/chris-an/home/4.22/Boj_1167.java
+++ b/chris-an/home/4.22/Boj_1167.java
@@ -1,0 +1,72 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.StringTokenizer;
+
+public class Boj_1167 {
+
+    static int V; // 트리의 정점의 개수
+    static ArrayList<ArrayList<Node>> nodeList = new ArrayList<>();
+    static boolean[] visited;
+    static int max, farNode;
+
+    static class Node {
+        int data;
+        int edge;
+
+        public Node(int data, int edge) {
+            this.data = data;
+            this.edge = edge;
+        }
+    }
+
+    static void dfs(int data, int disSum) {
+        visited[data] = true;
+
+        // 가장 먼 노드 data 최신화
+        if (disSum > max) {
+            max = disSum;
+            farNode = data;
+        }
+
+        // recur
+        for (Node childData : nodeList.get(data)) {
+            if (!visited[childData.data]) {
+                visited[childData.data] = true;
+                dfs(childData.data, childData.edge + disSum);
+            }
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        V = Integer.parseInt(br.readLine());
+
+        // list 초기화
+        for (int i = 0; i < V + 1; i++) {
+            nodeList.add(new ArrayList<>());
+        }
+
+        // 노드리스트 초기화
+        for (int i = 0; i < V; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            int node = Integer.parseInt(st.nextToken());
+
+            String tmp;
+            while (!(tmp = st.nextToken()).equals("-1")) {
+                int data = Integer.parseInt(tmp);
+                int edge = Integer.parseInt(st.nextToken());
+
+                nodeList.get(node).add(new Node(data, edge));
+            }
+        }
+
+        visited = new boolean[V + 1];
+        dfs(1, 0);
+        visited = new boolean[V + 1];
+        dfs(farNode, 0);
+
+        System.out.println(max);
+    }
+}

--- a/chris-an/home/4.22/Boj_11725.java
+++ b/chris-an/home/4.22/Boj_11725.java
@@ -1,0 +1,56 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class Boj_11725 {
+    static int N;
+    static ArrayList<ArrayList<Integer>> adjList = new ArrayList<>();
+    static int[] parentList;
+
+
+    static void bfs(){
+        Queue<Integer> qu = new LinkedList<>();
+        qu.offer(1);
+        parentList[1] = 1;
+
+        while (!qu.isEmpty()) {
+            int parent = qu.poll();
+
+            for (int i : adjList.get(parent)) {
+                if (parentList[i] == 0) {
+                    parentList[i] = parent;
+                    qu.offer(i);
+                }
+            }
+        }
+    }
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        N = Integer.parseInt(br.readLine());
+        parentList = new int[N + 1];
+        // 초기화
+        for (int i = 0; i < N + 1; i++) {
+            adjList.add(new ArrayList<>());
+        }
+        // 인접리스트 세팅
+        for (int i = 1; i < N; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+
+            int x = Integer.parseInt(st.nextToken());
+            int y = Integer.parseInt(st.nextToken());
+
+            adjList.get(x).add(y);
+            adjList.get(y).add(x);
+        }
+
+        bfs();
+
+        for (int i = 2; i < N + 1; i++) {
+            System.out.println(parentList[i]);
+        }
+    }
+}


### PR DESCRIPTION
### 1️⃣  트리의 지름
테스트 케이스를 가지고 그림을 그리니, 이해는 금방 됐습니다.
그런데, 처음에 생각할 때, 기준이 1인 줄 알았습니다.. 그래서 기준 루트가 1인 상태에서 최대값을 구하니, 틀렸다고 나왔습니다....
잘못된 로직 설계를 했는데, 생각해보니 기준(루트) 가 없는 상태에서 지름이 최대인 길이를 구하는 문제였습니다.
다시 설계를 하기 위해서 하나하나 다 찾을까 했는데, 시간 복잡도 효율이 엄청 떨어질 거 같았습니다.
그래서 찾아보니, 트리의 증명에 대한 어느정도 정형화된 게 있었습니다.
1) _임의의 정점으로 부터 가장 먼 정점을 구한다._
2) _1에서 나온 정점으로 부터 가장 먼 정점을 구한다._
3) _1과 2에서 나온 정점간의 거리가 트리의 지름_
위와 같은 규칙을 가질 수 있는 건, 트리의 지름 귀류법 증명을 통해서 알수 있습니다.
어느 정도 문제를 이해해보니, 알면 쉽게 접근할 수 있었던 문제 였습니다.

---
### 2️⃣ 트리의 부모 찾기
처음에 인접리스틀르 만들어서 인접리스트 중 0번 째리스트를 뽑고, 1이 루트니깐 리스트 중 1이 들어 있는 경우에, 부모노드를 1로 출력할 수 있게 설계를 했더니, `틀렸습니다.` 라고 나왔네요...
역시 설계하고 구현할 때 주먹구구식인 거 같아 틀릴 거 같았는데.. 후
다시, 인접리스트를 bfs로 돌려서 구현했더니, 비슷하듯 아닌 다른 로직이라 통과가 됐습니다.

