### PR TITLE
yoonji : boj 1167 트리의 지름 / 2250 트리의 높이와 너비 / 2146 다리만들기(추가)

### DIFF
--- a/yoonji/home/4/19/boj_2146.java
+++ b/yoonji/home/4/19/boj_2146.java
@@ -1,0 +1,113 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+// 다리 만들기
+public class boj_2146 {
+    static int N;
+    static int[][] map;
+    static boolean[][] visited;
+    static int[] dx = {-1, 1, 0, 0};
+    static int[] dy = {0, 0, -1, 1};
+    final static int SEA = 0;
+    static int minBridgeLen = Integer.MAX_VALUE;
+    static Queue<TileInfo> queForBridge = new LinkedList<>();
+    static Queue<TileInfo> que = new LinkedList<>();
+    static int landNum = 2;
+    public static void main(String[] args) throws IOException {
+        // 1. 초기화
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        N = Integer.parseInt(br.readLine());
+        map = new int[N][N];
+        visited = new boolean[N][N];
+        for (int i=0; i<N; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+            for (int j=0; j<N; j++) {
+                map[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+        //2. 섬 번호 매기기
+        for (int i=0; i<N; i++) {
+            for (int j=0; j<N; j++) {
+                if (map[i][j] == 1) setIslandNumbering(i,j);
+            }
+        }
+        // 3. 최소의 다리 짓기
+        // 모든 곳에서 시작해서 다리 길이를 재야함
+        // 이중 for문 내에서 visited를 매번 초기화하는 이유(debug)
+        for (int i=0; i<N; i++) {
+            for (int j=0; j<N; j++) {
+                // 어떤 섬에서부터 시작해야함.
+                if (map[i][j] >= 2) {
+                    initVisited();
+                    setBridge(i,j);
+                }
+            }
+        }
+        System.out.println(minBridgeLen);
+    }
+
+    private static void initVisited() {
+        for (int i=0; i<N; i++)
+            for (int j=0; j<N; j++)
+                visited[i][j] = false;
+    }
+    private static boolean isInBounds(int row, int col) {
+        return row >= 0 && row < N && col >= 0 && col < N;
+    }
+
+    private static void setIslandNumbering(int row, int col) {
+        que.offer(new TileInfo(row, col, 0));
+        visited[row][col] = true;
+        map[row][col] = landNum;
+        while (!que.isEmpty()) {
+            TileInfo t = que.poll();
+            for (int i=0; i<dx.length; i++) {
+                int nextR = t.row+dx[i];
+                int nextC = t.col+dy[i];
+                if (!isInBounds(nextR, nextC)) continue;
+                if (map[nextR][nextC] == SEA) continue;
+                // 방문 안한 섬인 경우
+                if (!visited[nextR][nextC]) {
+                    que.offer(new TileInfo(nextR, nextC, 0));
+                    visited[nextR][nextC] = true;
+                    map[nextR][nextC] = landNum;
+                }
+            }
+        }
+        landNum++;
+    }
+    private static void setBridge(int row, int col) {
+        queForBridge.offer(new TileInfo(row, col, 0));
+        visited[row][col] = true;
+        int currLandNum = map[row][col];
+        while (!queForBridge.isEmpty()) {
+            TileInfo t = queForBridge.poll();
+            for (int i=0; i<dx.length; i++) {
+                int nextR = t.row + dx[i];
+                int nextC = t.col + dy[i];
+                if (isInBounds(nextR, nextC) && !visited[nextR][nextC] && map[nextR][nextC] != currLandNum) {
+                    visited[nextR][nextC] = true;
+                    if (map[nextR][nextC] == SEA) {
+                        queForBridge.offer(new TileInfo(nextR, nextC, t.bridgeCnt+1));
+                    } else {
+                        minBridgeLen = Math.min(minBridgeLen, t.bridgeCnt);
+                        queForBridge.clear();
+                        return;
+                    }
+                }
+            }
+        }
+    }
+    static class TileInfo {
+        private int row;
+        private int col;
+        private int bridgeCnt;
+        public TileInfo(int row, int col, int bridgeCnt) {
+            this.row = row;
+            this.col = col;
+            this.bridgeCnt = bridgeCnt;
+        }
+    }
+}

--- a/yoonji/home/4/22/boj_1167.java
+++ b/yoonji/home/4/22/boj_1167.java
@@ -1,0 +1,64 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+// 트리의 지름
+// 트리의 지름을 구하는 방법
+//1. 가장 긴 길이를 갖고있는 정점을 구한다.
+//2. 가장 긴 길이의 정점을 기준으로 다시 거리를 측정한다.
+//3. 거리를 저장한 배열 중 최대값이 트리의 지름이다.
+public class boj_1167 {
+    static List<Relation>[] tree;
+    static boolean[] visited;
+    static class Relation {
+        private int to;
+        private int weight;
+        public Relation(int node, int dist) {
+            this.to = node;
+            this.weight = dist;
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        // 1. 초기화
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int V = Integer.parseInt(br.readLine());
+        tree = new List[V+1];
+        for (int i = 1; i <= V; i++) tree[i] = new ArrayList<>();
+        for (int i=0; i<V; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+            int node = Integer.parseInt(st.nextToken());
+            while(true) {
+                int dest = Integer.parseInt(st.nextToken());
+                if (dest == -1) break;
+                int dist = Integer.parseInt(st.nextToken());
+                tree[node].add(new Relation(dest, dist));
+            }
+        }
+        // 2. 지름 찾기
+        visited = new boolean[V+1];
+        visited[1] = true;
+        dfs(1, 0);  // 1에서 시작, 가중치 0
+        visited = new boolean[V+1];
+        visited[lastNode] = true;
+        dfs(lastNode, 0);   // 가장 멀리 있는 노드에서 시작, 가중치 0
+        System.out.println(maxWeight);
+    }
+    static int maxWeight = 0;
+    static int lastNode;
+    private static void dfs(int node, int weight) {
+        if (weight > maxWeight) {
+            maxWeight = weight;
+            lastNode = node;
+        }
+        for (Relation adj: tree[node]) {
+            if (!visited[adj.to]) {
+                visited[adj.to] = true;
+                dfs(adj.to, weight+adj.weight); // 가중치++
+            }
+        }
+    }
+}

--- a/yoonji/home/4/22/boj_2250.java
+++ b/yoonji/home/4/22/boj_2250.java
@@ -1,0 +1,87 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+// 트리의 높이와 너비
+public class boj_2250 {
+    static int N;
+    static List<Node> tree;
+    static int[] levelMin;
+    static int[] levelMax;
+    static int point = 1;   // x좌표. 노드 방문마다 point++ (-> 중위순회 필요)
+    static int treeHight = 0;  // 트리 높이
+    private static class Node{
+        private int parent;
+        private int left;
+        private int right;
+        public Node(int left, int right) {
+            this.parent = -1;   // 루트 노드가 1이라고 지정안되어있다는 점!
+            this.left = left;
+            this.right = right;
+        }
+    }
+    public static void main(String[] args) throws IOException {
+        makeTree();
+        int root = findRoot();
+        midSearch(root, 1);
+        findMaxDistance();
+    }
+
+    private static void makeTree() throws IOException{
+        // 1. 초기화
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        N = Integer.parseInt(br.readLine());
+        tree = new ArrayList<>();
+        levelMin = new int[N+1];
+        levelMax = new int[N+1];
+        // 숫자로 트리 생성
+        for (int i=0; i<=N; i++) {
+            tree.add(new Node(-1, -1));
+            levelMin[i] = N;
+        }
+        for (int i=0; i<N; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+            int data = Integer.parseInt(st.nextToken());
+            int left = Integer.parseInt(st.nextToken());
+            int right = Integer.parseInt(st.nextToken());
+            tree.get(data).left = left;
+            tree.get(data).right = right;
+            if (left != -1) tree.get(left).parent = data;
+            if (right != -1) tree.get(right).parent = data;
+        }
+    }
+    private static int findRoot() {
+        int root = 0;
+        for (int i=1; i<=N; i++)
+            if (tree.get(i).parent == -1) {
+                root = i;
+                break;
+            }
+        return root;
+    }
+    // 중위순회를 돌며 각 level의 min, max값 구하기
+    private static void midSearch(int node, int level) {
+        Node n = tree.get(node);
+        if (treeHight < level) treeHight = level;
+        if (n.left != -1) midSearch(n.left, level+1);   // 왼쪽
+        // 노드 처리
+        levelMin[level] = Math.min(levelMin[level], point);
+        levelMax[level] = point++;
+        if (n.right != -1) midSearch(n.right, level+1); // 오른쪽
+    }
+    private static void findMaxDistance() {
+        int maxDistance = levelMax[1] - levelMin[1] + 1;
+        int answerLevel = 1;
+        for (int i=2; i<=treeHight; i++) {
+            int dist = levelMax[i] - levelMin[i] + 1;
+            if (maxDistance < dist) {
+                answerLevel = i;
+                maxDistance = dist;
+            }
+        }
+        System.out.println(answerLevel+" "+maxDistance);
+    }
+}

--- a/yoonji/home/4/22/boj_2250.java
+++ b/yoonji/home/4/22/boj_2250.java
@@ -31,7 +31,6 @@ public class boj_2250 {
     }
 
     private static void makeTree() throws IOException{
-        // 1. 초기화
         BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
         N = Integer.parseInt(br.readLine());
         tree = new ArrayList<>();


### PR DESCRIPTION
## 1167 트리의 지름
### 설계
- 1에서 출발하여 가장 먼 노드를 찾고, 그 노드에서 다시 가장 먼 노드를 찾아서, 그중 최댓값의 길이가 지름이 된다.

### 부족했던 점
- 언제 가중치 값을 비교하면 될지 몰랐던 점
> Q. 트리를 두번 탐색하지 않았을 때 문제되는 반례를 아직 찾지못해서 왜 두번 해줘야하는지 이해하지 못했다.

## 2250 트리의 높이와 너비
### 설계
- 가장 왼쪽에 위치한 노드부터 x좌표가 정해지면 순차적으로 정해지므로, 중위순회가 알맞다.
- 중위순회를 하면서 
1. level 체크
2. 현재 x좌표 값이 현재 level에서 가장 왼쪽/오른쪽의 값인가? (각 level의 x좌표 min, max 값을 담을 배열 필요)
- parent, left, right를 프로퍼티로 갖는 Node 클래스 생성한다. (data는 ArrayList의 index로 대체 가능)

## 2146 다리만들기 (04.19 문제)
### 설계
> 필요한 내용은 주석으로 추가했습니다.
### 부족했던 점
- 다리를 짓는 로직에서, 바다가 시작될 때 (값이 0일 때) bfs 메서드를 호출하도록 했다.
=> 어떤 섬을 만나면 그 섬을 기준으로 섬일 때를 체크해야하므로 `2 이상일 때` bfs 메서드를 호출한다.
- 효율성을 항상 체크한다. 해당 문제에서는 크기가 100*100이 최대이니 효율성을 신경쓰지 않아도 되겠다는 생각을 하고 시작한다.
- 조건문을 체크하는 부분에서 시간을 많이 썼다.. (`setIslandNumbering`에서 바다인 경우 조건문을 따로 떼어서 체크한다.)

- 이중 for문으로 매 칸마다 bf를 호출하는 것이 비효율적으로 보이는 것 같긴 하다.
- 근데 visited를 왜 매번 재초기화해야하는지 모르겠다...
