### PR TITLE
Jungmin : Boj 16940 / Boj 16946

### DIFF
--- a/chris-an/home/4.25/Boj_16940.java
+++ b/chris-an/home/4.25/Boj_16940.java
@@ -1,0 +1,83 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+
+public class Boj_16940 {
+    static int N;
+    static ArrayList<ArrayList<Integer>> adjList = new ArrayList<>();
+    static boolean[] visited;
+    static int[] inputArr;
+    static Queue<Integer> qu = new LinkedList<>();
+    static StringTokenizer st;
+
+    public static void main(String[] args) throws IOException{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        N = Integer.parseInt(br.readLine());
+        visited = new boolean[N + 1];
+        inputArr = new int[N + 1];
+
+
+        for(int i = 0; i < N + 1; i++) {
+            adjList.add(new ArrayList<>());
+        }
+
+        for(int i = 0; i < N - 1; i++) {
+            st = new StringTokenizer(br.readLine());
+
+            int x = Integer.parseInt(st.nextToken());
+            int y = Integer.parseInt(st.nextToken());
+            adjList.get(x).add(y);
+            adjList.get(y).add(x);
+        }
+
+        // input 데이터 저장
+        st = new StringTokenizer(br.readLine());
+        for(int i = 1; i < N + 1; i++) {
+            inputArr[i] = Integer.parseInt(st.nextToken());
+        }
+
+        isPossibleBfs(1);
+    }
+
+    public static void isPossibleBfs(int x) {
+        // 시작이 1이 아니면 0으로 아웃
+        if(inputArr[1] != 1) {
+            System.out.println(0);
+            return;
+        }
+
+        qu.offer(x);
+        visited[x] = true;
+
+        int index = 2;
+        while(!qu.isEmpty()) {
+            int cur = qu.poll();
+
+            // 현재 노드의 자식들 방문 처리
+            int count = 0;
+            for(int next : adjList.get(cur)) {
+                if(!visited[next]) {
+                    visited[next] = true;
+                    count++;
+                }
+            }
+
+            for(int i = index; i < (index + count); i++) {
+                // 정답이 현재 노드의 자식이 아니라면 X
+                if(!visited[inputArr[i]]) {
+                    System.out.println(0);
+                    return;
+                } else qu.offer(inputArr[i]); // 정답이 현재 노드의 자식이면 큐에 순서대로 삽입
+            }
+            index += count;
+        }
+
+        System.out.println(1);
+    }
+}

--- a/chris-an/home/4.25/Boj_16964.java
+++ b/chris-an/home/4.25/Boj_16964.java
@@ -1,0 +1,71 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.StringTokenizer;
+
+public class Boj_16964 {
+    private static boolean[] visited;
+    private static int N;
+    private static int[] inputArr;
+    private static ArrayList<ArrayList<Integer>> adjList = new ArrayList<>();
+    private static int[] parent;
+    private static StringTokenizer st;
+    private static boolean flag;
+
+    public static void main(String[] args) throws NumberFormatException, IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        N = Integer.parseInt(br.readLine());
+
+        visited = new boolean[N + 1];
+        inputArr = new int[N + 1];
+        parent = new int[N + 1];
+
+        for (int i = 0; i < N + 1; i++) {
+            adjList.add(new ArrayList<>());
+        }
+
+        for (int i = 0; i < N - 1; i++) {
+            st = new StringTokenizer(br.readLine());
+            int x = Integer.parseInt(st.nextToken());
+            int y = Integer.parseInt(st.nextToken());
+            adjList.get(x).add(y);
+            adjList.get(y).add(x);
+        }
+
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++) {
+            inputArr[i] = Integer.parseInt(st.nextToken());
+        }
+
+        isPossibleDfs(1, 0);
+
+        if (flag) System.out.println(0);
+        else System.out.println(1);
+    }
+
+    private static void isPossibleDfs(int x, int index) {
+        if (flag) return;
+
+
+        visited[x] = true;
+        int count = 0;
+        for (int next : adjList.get(x)) {
+            if (!visited[next]) {
+                visited[next] = true;
+                parent[next] = x;
+                count++;
+            }
+        }
+
+        index++;
+        for (int i = 0; i < count; i++) {
+            if (parent[inputArr[index]] != x) {
+                flag = true;
+                return;
+            }
+            isPossibleDfs(inputArr[index], index);
+        }
+    }
+}


### PR DESCRIPTION
### 1️⃣  BFS 스페셜저지
처음 문제 접근했을 때, 비슷하게 접근을 했지만, 구현 쪽에서 막혔습니다.
이번에 구현을 했을 때의 `index + count` 만큼 루프를 따로 돌려주는 방법으로 비슷한  로직을 
전에 다른 문제에서 적용한 기억이 있는데, 이 걸 잘 활용을 못했던 거 같습니다.
문제를 풀면서 정리한 건,
아래 부분을 신경 써서 문제를 구현해야 했던 문제 였습니다.
    1. 시작 정점은 1이기 때문에 1이 아닌 다른 정점부터 시작하는 방문 순서는 올바르지 않습니다.
    2. 간선은 양방향으로 저장
    3. 같은 레벨에 있는 정점들의 순서만 중요합니다. 
    4. 즉, 한 정점에서 이동하는 정점들과 다른 정점에서 이동하는 정점들의 순서가 섞이면 안 됩니다

---
### 2️⃣  DFS 스페셜저지
BFS 문제와 동일하게 접근 하였습니다.

---

> 위 두 문제를 다시 풀어야할 거 같습니다. 방문 순서에 대한 문제여서 익숙해지면 다른 문제에 응용하기 좋을 거 같습니다.
