### PR TITLE
Jungmin : Boj 15658

### DIFF
--- a/chris-an/home/5.05/Boj_15658.java
+++ b/chris-an/home/5.05/Boj_15658.java
@@ -1,0 +1,90 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Boj_15658 {
+    static final int operatorCnt = 4; // +,-,*,/
+    static int N;
+    static int[] numbers;
+    static int[] operators;
+    static boolean[] visited = new boolean[44];
+    static int[] temp = new int[10];
+    static int max = Integer.MIN_VALUE;
+    static int min = Integer.MAX_VALUE;
+
+    public static int calc() {
+        int sum = numbers[0];
+        for (int i = 0 ; i < N-1; i++) {
+            switch (temp[i]) {
+                case 0 :
+                    sum += numbers[i + 1]; break;
+                case 1 :
+                    sum -= numbers[i + 1]; break;
+                case 2 :
+                    sum *= numbers[i + 1]; break;
+                case 3 :
+                    sum /= numbers[i + 1]; break;
+            }
+        }
+        return sum;
+    }
+
+    public static void dfs(int depth) {
+        // base case
+        if (depth == N-1) {
+            int sum = calc();
+            max = Math.max(max, sum);
+            min = Math.min(min, sum);
+            return;
+        }
+
+        // recur
+        int beforeOperators = -1;
+        for (int i = 0; i < operators.length; i++) {
+            if (!visited[i] && operators[i] != beforeOperators) { // 이전 연산자와 동일할 시, 동일한 조합이 만들어짐으로 pass
+                visited[i] = true;
+                beforeOperators = operators[i]; // 동일한 연산자 조합을 피하기 위해 저장해 놓습니다.
+                temp[depth] = operators[i];
+                dfs(depth + 1);
+                visited[i] = false;
+            }
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+        N = Integer.parseInt(br.readLine());
+
+        // 피연산자 저장배열 : numbers
+        numbers = new int[N];
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++)
+            numbers[i] = Integer.parseInt(st.nextToken());
+
+
+
+        st = new StringTokenizer(br.readLine());
+        int[] op = new int[4];
+        int totalOperatorCnt = 0;
+        for (int i = 0; i < operatorCnt; i++) {
+            int operator = Integer.parseInt(st.nextToken());
+            op[i] = operator;
+            totalOperatorCnt += operator;
+        }
+
+        // 연산자 저장배열 : operators
+        operators = new int[totalOperatorCnt];
+        int oIdx = 0;
+        for (int i = 0; i < op.length; i++) {
+            for (int j = 0; j < op[i]; j++) {
+                operators[oIdx++] = i;
+            }
+        }
+
+        dfs(0);
+        System.out.println(max);
+        System.out.println(min);
+    }
+}


### PR DESCRIPTION
### 1️⃣  연산자 끼워넣기(2)
앞선 문제 연산자 끼워넣기 로직에서 약간만 변형하면 된다고 생각했지만, 시간초과가 떴습니다.
이전 로직을 현 문제에 적용하여 수정한 로직은 44개의 연산자 중, 10개의 조합을 찾는 거라 24억이 넘어가, 시간복잡도가 높았습니다.
수정된 로직에서 큰 틀은 
1. dfs 에 recur 루프 도는 부분에서, `beforeOperators` 이전 연산자를 기억하게끔 하여, 이전 연산자가 동일하게 나올 시, pass 하게끔 합니다.
2. 원래는 recur 부분에서 연산작업을 depth N-1까지 하면서 루프를 돌다가, 목표 depth가 도달할 때, 최대 최소비교를 하였는데,  수정된 로직은 조합을 구하고 그 조합을 가지고 연산작업을 하게끔 바꿨습니다. (조합을 구하는 과정에서 중복은 recur를 x)
3. `operators` 연산자 배열을 미리 전역변수로 선언한 걸, 입력받은 연산자 갯수에 맞게끔 초기화를 할 수 있도록 로직 수정을 했습니다.