### PR TITLE
yoonji: prg 점프와순간이동

### DIFF
--- a/yoonji/office/5/10/prg_점프와순간이동.java
+++ b/yoonji/office/5/10/prg_점프와순간이동.java
@@ -1,2 +1,22 @@
-package PACKAGE_NAME;public class prg_점프와순간이동 {
+// dp[i] = i번째 까지의 점프 최소 거리
+// 5000 -> 2500 -> 1250 -> 625 -> 624 (answer++) -> 312 -> ....-> 1 -> 0 (answer++)
+public class prg_점프와순간이동 {
+    public int solution(int n) {
+        if (n<=2) return 1;
+        recur(n);
+        return answer;
+    }
+    int answer = 0;
+    public void recur(int n) {
+        if (n==1) {
+            answer++;   // 1->0 jump
+            return;
+        }
+        if (n%2 == 0) {
+            recur(n/2);
+        } else {
+            answer++;
+            recur((n-1)/2);
+        }
+    }
 }


### PR DESCRIPTION
## prg 점프와순간이동
### 접근 흐름
- 처음에는 앞에서부터 `dp[i-1]+1`과 `dp[i/2]`의 min값으로 dp[i]를 구해갔다.
- TC에서 시간초과가 떠서 재귀로 시도했는데도, 마찬가지로 시간초과 떠서 다시 로직을 접근했다.
- 예제 3번째 값이 크길래 5000부터 /2와 -1을 하며 계산해갔고 규칙이 보였다.
- 재귀 그대로 가되, n부터 시작하도록 변경했다.

➕ `n`이 2보다 작거나 같은 경우 `recur` 메서드 자체를 호출하기전에 return하도록 했다.