### PR TITLE
Jungmin : Boj 12886 / SW 오목판정

### DIFF
--- a/chris-an/home/5.21/Boj_12886.java
+++ b/chris-an/home/5.21/Boj_12886.java
@@ -1,0 +1,93 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Boj_12886 {
+
+    static Queue<StoneGroup> qu;
+    static int[] arr = new int[3];
+    static boolean[] permCheck = new boolean[3];
+    static boolean[][] visited;
+    static int result = 0; // 초기는 0 (없다)
+
+    static class StoneGroup {
+        int stone1;
+        int stone2;
+        int stone3;
+
+        public StoneGroup(int stone1, int stone2, int stone3) {
+            this.stone1 = stone1;
+            this.stone2 = stone2;
+            this.stone3 = stone3;
+        }
+    }
+
+    static void calculateStone() {
+        List<Integer> li = new ArrayList<>();
+        int ex = 0;
+        for (int i = 0 ; i < 3; i++) {
+            if (permCheck[i]) li.add(arr[i]);
+            else ex = arr[i];
+        }
+        if (li.get(0) == li.get(1)) return;
+
+        int small = Math.min(li.get(0), li.get(1));
+        int big = Math.max(li.get(0), li.get(1));
+        int newStoneA = small + small;
+        int newStoneB = big - small;
+
+        if (!visited[small][big]) {
+            visited[small][big] = true;
+            visited[big][small] = true;
+            qu.offer(new StoneGroup(newStoneA, newStoneB, ex));
+        }
+    }
+
+    static void dfs(int start, int depth) {
+        if (depth == 2) {
+            calculateStone();
+            return;
+        }
+
+        for (int i = start; i < 3; i++) {
+            permCheck[i] = true;
+            dfs(i + 1, depth + 1);
+            permCheck[i] = false;
+        }
+    }
+
+    static void bfs() {
+        while (!qu.isEmpty()) {
+            StoneGroup sg = qu.poll();
+            int a = sg.stone1;
+            int b = sg.stone2;
+            int c = sg.stone3;
+            if (a > 1000 || b > 1000 || c > 1000) continue;
+
+            if (a == b && b == c) {
+                result = 1;
+                return;
+            }
+            arr = new int[3];
+            permCheck = new boolean[3];
+            arr[0] = a; arr[1] = b; arr[2] = c;
+
+            dfs(0, 0);
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < 3; i++) {
+            arr[i] = Integer.parseInt(st.nextToken());
+        }
+        visited = new boolean[1001][1001];
+        qu = new LinkedList<>();
+        qu.offer(new StoneGroup(arr[0], arr[1], arr[2]));
+        bfs();
+        System.out.println(result);
+    }
+}

--- a/chris-an/home/5.21/Sw_오목판정.java
+++ b/chris-an/home/5.21/Sw_오목판정.java
@@ -1,0 +1,87 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class Sw_오목판정 {
+    static Character[][] board;
+    static int N;
+
+    static boolean isPossible(int x, int y) {
+        int cnt = 0;
+        for (int i = 1; i <= 2; i++) {
+            // 12시, 6시,
+            if (x - i < 0 || x + i >= N) continue;
+            if (board[x - i][y] == 'o' && board[x + i][y] == 'o') {
+                cnt++;
+            }
+        }
+        if (cnt == 2) return true;
+
+
+        cnt = 0;
+        for (int i = 1; i <= 2; i++) {
+            // 1시, 7시,
+            if (x - i < 0 || x + i >= N || y + i >= N || y - i < 0) continue;
+            if (board[x - i][y + i] == 'o' && board[x + i][y - i] == 'o') {
+                cnt++;
+            }
+        }
+        if (cnt == 2) return true;
+
+        cnt = 0;
+        for (int i = 1; i <= 2; i++) {
+            // 3시, 9시,
+            if (y - i < 0 || y + i >= N) continue;
+            if (board[x][y + i] == 'o' && board[x][y - i] == 'o') {
+                cnt++;
+            }
+        }
+        if (cnt == 2) return true;
+
+        cnt = 0;
+        for (int i = 1; i <= 2; i++) {
+            // 5시, 11시,
+            if (x - i < 0 || x + i >= N || y + i >= N || y - i < 0) continue;
+            if (board[x + i][y + i] == 'o' && board[x - i][y - i] == 'o') {
+                cnt++;
+            }
+        }
+        if (cnt == 2) return true;
+
+
+        return false;
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int T = Integer.parseInt(br.readLine());
+        for (int tc = 1; tc <= T; tc++) {
+            N = Integer.parseInt(br.readLine());
+
+            board = new Character[N][N];
+            for (int i = 0; i < N; i++) {
+                String line = br.readLine();
+                for (int j = 0; j < N; j++) {
+                    board[i][j] = line.charAt(j);
+                }
+            }
+
+            boolean flag = false;
+            String result = "NO";
+            for (int i = 0; i < N; i++) {
+                for (int j = 0; j < N; j++) {
+                    if (board[i][j] == 'o') {
+                        if (isPossible(i, j)) {
+                            flag = true;
+                            result = "YES";
+                            break;
+                        }
+                    }
+                }
+                if (flag) break;
+            }
+            System.out.println("#" + tc + " " + result);
+        }
+    }
+}


### PR DESCRIPTION
## 돌그룹
처음에 설계를 할 때, dfs, bfs 둘 다 사용해야 한다고 생각했습니다.
`bfs` -> `dfs` -> `calculate` -> `bfs` -> `dfs` -> `calculate` ....
이렇게 로직을 돌게끔 설계를 했고, 구현했습니다.

구현 도중에 조합 dfs 에서 그냥 두 값만 뽑게끔 dfs를 구현 했는데,  세 그룹을 다 알고 있어야해서 dfs 로직을 visited 로 재 설계해서 세 수를 다 알 수 있게 로직 수정을 하였고.
다 구현 했을 때, 바로 통과가 안되고 로직확인이 필요했습니다. 
코드를 다시 확인하면서 부족했던 거 check 하면서 수정을 하니 통과됐습니다.

_로직 설계 부족했던 점_.
1. 무한루프. 문제에서 언급한 동일한 값이 아닌 크기가 다른 두 그룹이라는 글귀를 놓침
2. 메모리초과. 이 부분은 visited를 하나 만들어서 방문처리로 해결
3. 틀렸다고 뜸. 이 부분은 `1번`을 다르게 해석해서, qu에서 뽑을 때, a==b && a==c && b==c 는 continue 로 설계해서 설계 오류가 남.
> 시간은 많이 걸린 건 아니지만, 문제가 단순해서 대충 읽다가 잦은 실수가 많았습니다.
그리고 이번 문제는 더 쉽게 풀수 있을 거 같다는 생각이 들어, 리팩토링좀 해야할 거 같네요.

## 오목판정
처음에는 bfs 로직인 줄 알고, 대충 머리로만 설계를 하고 구현했지만, bfs가 아닌 거 같아 그냥 for문으로 구현처리 했습니다.
<img width="426" alt="Screen Shot 2022-05-21 at 7 59 58 AM" src="https://user-images.githubusercontent.com/71064490/169622576-1b19bf5d-4b64-40c5-975d-a970b991a4a0.png">

처음에는 8방면을 하나하나 확인해줄까 했다가?
4루프 내에서 중심 앞뒤로 한 칸씩 확인하는 로직으로 구현했습니다. `isPossible` 부분.
