### PR TITLE
Jungmin : Sw 문자열나누기 (+팔씨름) / Boj 2206 / Boj 16946

### DIFF
--- a/chris-an/home/5.25/Boj_16946.java
+++ b/chris-an/home/5.25/Boj_16946.java
@@ -1,0 +1,144 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Boj_16946 {
+
+    static int N, M;
+    static int[][] board;
+    static final int fourDirection = 4;
+    static int[] dx = {-1, 0, 1, 0};
+    static int[] dy = {0, 1, 0, -1};
+    static List<Integer> al;
+    static int[][] resultBoard;
+
+    static class Node {
+        int x;
+        int y;
+
+        public Node(int x, int y) {
+            this.x = x;
+            this.y = y;
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+
+        board = new int[N][M];
+        for (int i = 0; i < N; i++) {
+            String line = br.readLine();
+            for (int j = 0; j < M; j++) {
+                board[i][j] = line.charAt(j) - '0';
+            }
+        }
+
+        bfsGroupSetting();
+        resultBoardSetting();
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < M; j++) {
+                sb.append(resultBoard[i][j]);
+            }
+            sb.append('\n');
+        }
+        System.out.println(sb);
+    }
+
+    private static void resultBoardSetting() {
+        resultBoard = new int[N][M];
+
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < M; j++) {
+                if (board[i][j] == 1) {
+                    resultBoard[i][j] = calculateBoard(i, j);
+                }
+            }
+        }
+    }
+
+    private static int calculateBoard(int x, int y) {
+        int sum = 1;
+        Set<Integer> set = new HashSet<>();
+        for (int i = 0; i < fourDirection; i++) {
+            int nx = x + dx[i];
+            int ny = y + dy[i];
+
+            if (nx < 0 || ny < 0 || nx >= N || ny >= M) continue;
+
+            if (board[nx][ny] != 1) {
+                set.add(board[nx][ny]);
+            }
+        }
+        for (int i : set) {
+            sum += al.get(i);
+        }
+        return sum % 10;
+    }
+
+
+    private static void bfsGroupSetting() {
+        al = new ArrayList<>();
+        al.add(0); al.add(0);
+
+        int groupNum = 2;
+        for (int i = 0 ; i < N; i++) {
+            for (int j = 0; j < M; j++) {
+                // 이동 가능할 시?
+                if (board[i][j] == 0) {
+                    bfs(groupNum++, i, j);
+                }
+            }
+        }
+    }
+
+    private static void bfs(int idx, int x, int y) {
+        Queue<Node> qu = new LinkedList<>();
+        qu.offer(new Node(x, y));
+        board[x][y] = idx;
+
+        int sum = 1;
+        while (!qu.isEmpty()) {
+            Node point = qu.poll();
+
+            for (int i = 0; i < fourDirection; i++) {
+                int nx = point.x + dx[i];
+                int ny = point.y + dy[i];
+
+                if (nx < 0 || ny < 0 || nx >= N || ny >= M) continue;
+
+                if (board[nx][ny] == 0) {
+                    sum++;
+                    board[nx][ny] = idx;
+                    qu.offer(new Node(nx, ny));
+                }
+            }
+        }
+        al.add(sum);
+    }
+}
+
+/*
+    private static int calculateBoard(int x, int y) {
+        int sum = 1;
+        List<Integer> copyAl = new ArrayList<>(al);
+        for (int i = 0; i < fourDirection; i++) {
+            int nx = x + dx[i];
+            int ny = y + dy[i];
+
+            if (nx < 0 || ny < 0 || nx >= N || ny >= M) continue;
+
+            if (board[nx][ny] != 1) {
+                sum += copyAl.get(board[nx][ny]);
+                copyAl.set(board[nx][ny], 0);
+            }
+        }
+        return sum % 10;
+    }
+ */

--- a/chris-an/home/5.25/Boj_2206.java
+++ b/chris-an/home/5.25/Boj_2206.java
@@ -1,0 +1,90 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class Boj_2206 {
+
+    static int N, M;
+    static char[][] board;
+    static boolean[][][] visited;
+    static int min = Integer.MAX_VALUE;
+    static final int fourDirection = 4;
+    static int[] dx = {-1, 0, 1, 0};
+    static int[] dy = {0, 1, 0, -1};
+
+    static class WallLocAndStatus {
+        int x;
+        int y;
+        int movedCnt;
+        int crashCheck;
+
+        public WallLocAndStatus(int x, int y, int movedCnt, int crashCheck) {
+            this.x = x;
+            this.y = y;
+            this.movedCnt = movedCnt;
+            this.crashCheck = crashCheck;
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+
+        board = new char[N][M];
+        visited = new boolean[2][N][M];
+        for (int i = 0 ; i < N; i++) {
+            board[i] = br.readLine().toCharArray();
+        }
+
+        if (bfs()) System.out.println(min);
+        else System.out.println(-1);
+    }
+
+    private static boolean bfs() {
+        Queue<WallLocAndStatus> qu = new LinkedList<>();
+        visited[0][0][0] = true;
+        qu.offer(new WallLocAndStatus(0, 0, 1, 0));
+
+        while (!qu.isEmpty()) {
+            WallLocAndStatus point = qu.poll();
+
+            if (point.x == N-1 && point.y == M-1) {
+                min = point.movedCnt;
+                return true;
+            }
+            for (int i = 0; i < fourDirection; i++) {
+                int nx = point.x + dx[i];
+                int ny = point.y + dy[i];
+
+                if (nx < 0 || ny < 0 || nx >= N || ny >= M) continue;
+
+                // 옮긴 위치가 벽이 있다.
+                if (board[nx][ny] == '1') {
+                    // 벽을 부순 적이 있다.
+                    if (point.crashCheck == 1) continue;
+                        // 벽을 부순 적이 없다.
+                    else {
+                        if (visited[1][nx][ny]) continue;
+
+                        visited[1][nx][ny] = true;
+                        qu.offer(new WallLocAndStatus(nx, ny, point.movedCnt + 1, 1));
+                    }
+                    // 옮긴 위치가 벽이 없다. (벽을 부쉈고 안 부쉈고 double Checking)
+                }else {
+                    if (visited[point.crashCheck][nx][ny]) continue;
+
+                    visited[point.crashCheck][nx][ny] = true;
+                    qu.offer(new WallLocAndStatus(nx, ny, point.movedCnt + 1, point.crashCheck));
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/chris-an/home/5.25/Boj_2206_failed_시간초과.java
+++ b/chris-an/home/5.25/Boj_2206_failed_시간초과.java
@@ -1,0 +1,116 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class Boj_2206_failed_시간초과 {
+    static int N, M;
+    static char[][] board;
+    static boolean[][] visited;
+    static Queue<WallLocation> quWall;
+    static int min = Integer.MAX_VALUE;
+    static final int fourDirection = 4;
+    static int[] dx = {-1, 0, 1, 0};
+    static int[] dy = {0, 1, 0, -1};
+    static boolean flag;
+
+    static class WallLocation {
+        int x;
+        int y;
+
+        public WallLocation(int x, int y) {
+            this.x = x;
+            this.y = y;
+        }
+    }
+
+    static class Node {
+        int x;
+        int y;
+        int movedCnt;
+
+        public Node(int x, int y, int movedCnt) {
+            this.x = x;
+            this.y = y;
+            this.movedCnt = movedCnt;
+        }
+    }
+
+    private static void bfsSetting() {
+        char[][] copyBoard = new char[N][M];
+        WallLocation wall = quWall.poll();
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < M; j++) {
+                copyBoard[i][j] = board[i][j];
+            }
+        }
+        copyBoard[wall.x][wall.y] = '0';
+
+        bfs(copyBoard);
+    }
+
+    private static void bfs(char[][] copyBoard) {
+        Queue<Node> quNode = new LinkedList<>();
+        visited = new boolean[N][M];
+
+        quNode.offer(new Node(0, 0, 1));
+        visited[0][0] = true;
+
+        while (!quNode.isEmpty()) {
+            Node point = quNode.poll();
+
+            if (point.x == N-1 && point.y == M-1) {
+                min = Math.min(min, point.movedCnt);
+                flag = true;
+                return;
+            }
+            for (int i = 0; i < fourDirection; i++) {
+                int nx = point.x + dx[i];
+                int ny = point.y + dy[i];
+
+                if (nx < 0 || ny < 0 || nx >= N || ny >= M) continue;
+                if (visited[nx][ny]) continue;
+                if (copyBoard[nx][ny] == '1') continue;
+
+                visited[nx][ny] = true;
+                quNode.offer(new Node(nx, ny, point.movedCnt + 1));
+            }
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+
+        board = new char[N][M];
+        quWall = new LinkedList<>();
+
+        for (int i = 0; i < N; i++) {
+            String line = br.readLine();
+            for (int j = 0; j < M; j++) {
+                board[i][j] = line.charAt(j);
+
+                if (board[i][j] == '1') {
+                    quWall.offer(new WallLocation(i, j));
+                }
+            }
+        }
+
+        // 벽을 돌리지 않은 상태에서 bfs 돌리기
+        bfs(board);
+
+        // 벽을 한 개 없애고 돌리기
+        for (int i = 0; i < quWall.size(); i++) {
+            bfsSetting();
+        }
+
+        if (flag) System.out.println(min);
+        else System.out.println("-1");
+    }
+}

--- a/chris-an/home/5.25/Sw_문자열나누기.java
+++ b/chris-an/home/5.25/Sw_문자열나누기.java
@@ -1,0 +1,25 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+class Sw_문자열나누기 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int T = Integer.parseInt(br.readLine());
+        for (int tc = 1; tc <= T; tc++) {
+            String line = br.readLine();
+            String previousCharValue = "";
+            String currentCharValue = "";
+            int cnt = 0;
+            for (int i = 0; i < line.length(); i++) {
+                currentCharValue += line.charAt(i);
+                if (!currentCharValue.equals(previousCharValue)) {
+                    previousCharValue = currentCharValue;
+                    currentCharValue = "";
+
+                    cnt++;
+                }
+            }
+            System.out.println("#" + tc + " " + cnt);
+        }
+    }
+}

--- a/chris-an/home/5.25/Sw_팔씨름.java
+++ b/chris-an/home/5.25/Sw_팔씨름.java
@@ -1,0 +1,23 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class Sw_팔씨름 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int T = Integer.parseInt(br.readLine());
+        for (int tc = 1; tc <= T; tc++) {
+            String line = br.readLine();
+
+            int sum = 0;
+            for (int i = 0; i < line.length(); i++) {
+                if (line.charAt(i) == 'x') {
+                    sum++;
+                }
+            }
+
+            if (sum > 7) System.out.println("#" + tc + " " + "NO");
+            else System.out.println("#" + tc + " " + "YES");
+        }
+    }
+}


### PR DESCRIPTION
## 문자열나누기
이번 문제는 알고리즘을 어떤 걸 사용해야 하는 지 고민을 계속 했던 거 같습니다.
DP? 인건가 아니면, 익숙하지 않아서 모르지만 그리디인건가? 그래서 그리디 문제도 보고 이것저것 찾아보았지만,
이번 문제를 어떻게 구현해야할지 정리가 안되서, 문제 그대로 생각하고 구현해보자고 생각하고
가정을 세워서 문제를 풀었습니다.
인접한 값이 같으면 안되니깐, 
인접한 값이 같을 시 문자열을 다음 인접한 값을 문자열에 추가하여 비교하고, 인접한 값이 다를 경우 count 하고? 이전 값을 현재값으로 초기화하면서 계속 반복해주었습니다.
여러가지 테케를 만들어서 해봤을 때, 계속해서 정답이 나와 바로 구현했습니다.
> 이번 문제는 알고 분류가 뭘까요..

## 벽 부수고 이동하기
이번 문제는 처음 로직을 구상하고 풀었을 때, 시간초과가 났습니다.
시간 초과가 나는 건, 벽을 하나 씩 빼가면서 bfs 를 돌려서 그랬습니다. (복잡도는 1000*1000..)
계속 생각하다가 생각이나질 않아, 찾아보니 다른 분들은 3차원 방문처리를 이용해서 푸는 걸 보고,
그걸로 다시 로직 설계를 했습니다.
로직 설계 중에 3차원 방문처리로 푸는 과정을 다 이해하지 않고 바로 구현을 했다보니 계속 틀렸다고 나왔네요.
놓치고 있던 부분은 3차원으로 할 때, 0,1을 구분을 해줘서 해당 Node가 crash를 했는 지 안했는지 여부에 따라, 구분지어 qu에 다 넣어서 bfs를 계속 돌려줘야 했었습니다.
> 3차원 boolean 배열을 이용해서, 이렇게 시간초과를 줄이는 방법을 알게 됐네요.

## 벽 부수고 이동하기4
이번 문제는 전 문제를 풀어봐서 그런지, 보드에 있는 칸 하나씩 bfs를 돌리면 시간초과가 날 것이라 생각을 해서 다른 접근으로 bfs를 풀어야한다고 생각하고 로직 설계를 했습니다.
그래서 1(벽)기준이 아닌 0(빈)기준으로 설계를 했고, 
0(빈) 그룹으로 나눠서 각 그룹마다 칸의 개수가 몇 인지 ArrayList 에 담아서 벽마다 갈 수 있는 위치의 값을 파악했습니다.
그런데도 시간초과가 났습니다.
시간초과가 난 건, 마지막 resultBoard 를 세팅하는 과정에서 중복되는 그룹 idx 가 있어서 결과값이 다르게 나와, 중복된 idx를 거르고자 ArrayList를 copy 해서 remove, contains를 사용했는데, 이 부분을 set 자료구조료 변경하니 통과 됐습니다.
처음 설계한 메서드는 아래 주석을 달아 놓았습니다
> bfs 탐색할 때 시간 복잡도를 줄이고자. 문제를 해석하고 설계할 때 많이 고민한 점이 좋았습니다. 