### PR TITLE
yoonji : boj 벽부수고 이동하기2,4, 3(추가 commit) / prg 피로도 & 캐시 & 영어끝말잇기

### DIFF
--- a/yoonji/home/5/boj_14442_25.java
+++ b/yoonji/home/5/boj_14442_25.java
@@ -1,2 +1,88 @@
-package PACKAGE_NAME;public class boj_14442_25 {
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+// 벽 부수고 이동하기2
+// 벽을 K개 까지 부술 수 있음.
+// 1<=N,M<=1000,  1<=K<=10
+// 최단거리 출력. 불가능하면 -1
+/**
+ * K-?개를 부수고 이동한 경로들 / 안부수고 이동한 경로들 중 가장 가까운 최솟값을 구하려면
+ * 각각의 방문처리를 따로 해줘야 한다.
+ * visited의 길이가 boolean[N][M][K] 어야 한다.
+ * 다 부수고 특정 칸에 먼저 도착해도, 이후에 N,M에 도달하지 못하는 경로일 수 있기 때문에!
+ * 아예 안부신 경우, K이고 부신 경우 그만큼 K-1
+ */
+public class boj_14442_25 {
+    private static final int WALL = 1;
+    private static int[][] dir = {{1, 0}, {0, -1}, {-1, 0}, {0, 1}};
+    private static int[][] grid;
+    private static int N,M;
+    private static boolean[][][] visited;
+    private static int K;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        K = Integer.parseInt(st.nextToken());
+        grid = new int[N][M];
+        visited = new boolean[N][M][K+1];
+        for (int i=0; i<N; i++) {
+            String row = br.readLine();
+            for (int j=0; j<M; j++) {
+                grid[i][j] = row.charAt(j) - '0';
+            }
+        }
+        int minRoute = getMinRoute_bfs();
+        System.out.println(minRoute);
+    }
+    // 목표지점은 N-1, M-1
+    private static int getMinRoute_bfs() {
+        int minRoute = -1;
+        Queue<RouteInfo> que = new LinkedList<>();
+        que.add(new RouteInfo(0, 0, K, 1));
+        visited[0][0][K] = true;
+        while (!que.isEmpty()) {
+            RouteInfo curr = que.poll();
+            if (curr.col == M-1 && curr.row == N-1) {
+                minRoute = curr.moveCnt;
+                break;
+            }
+            for (int i=0; i<4; i++) {
+                int nxtRow = curr.row + dir[i][1];
+                int nxtCol = curr.col + dir[i][0];
+                if (isOutOfBound(nxtRow, nxtCol)) continue;
+                if (grid[nxtRow][nxtCol] == WALL) {
+                    if (curr.remainCrushCnt>0 && !visited[nxtRow][nxtCol][curr.remainCrushCnt-1]) {
+                        visited[nxtRow][nxtCol][curr.remainCrushCnt - 1] = true;
+                        que.add(new RouteInfo(nxtRow, nxtCol, curr.remainCrushCnt - 1, curr.moveCnt+1));
+                    }
+                } else {
+                    if (visited[nxtRow][nxtCol][curr.remainCrushCnt]) continue;
+                    visited[nxtRow][nxtCol][curr.remainCrushCnt] = true;
+                    que.add(new RouteInfo(nxtRow, nxtCol, curr.remainCrushCnt, curr.moveCnt+1));
+                }
+            }
+        }
+        return minRoute;
+    }
+    private static boolean isOutOfBound(int row, int col) {
+        return row<0 || row>=N || col <0 || col>=M;
+    }
+    private static class RouteInfo {
+        int row;
+        int col;
+        int remainCrushCnt;
+        int moveCnt;
+        RouteInfo(int r, int c, int remainCrushCnt, int moveCnt) {
+            this.row = r;
+            this.col = c;
+            this.remainCrushCnt = remainCrushCnt;
+            this.moveCnt = moveCnt;
+        }
+    }
 }

--- a/yoonji/home/5/boj_14442_25.java
+++ b/yoonji/home/5/boj_14442_25.java
@@ -1,0 +1,2 @@
+package PACKAGE_NAME;public class boj_14442_25 {
+}

--- a/yoonji/home/5/boj_16933_26.java
+++ b/yoonji/home/5/boj_16933_26.java
@@ -1,0 +1,88 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+// 벽부수고 이동하기 3
+// 한칸 이동 or 머무를 때 마다 낮-밤이 바뀐다.
+// 인접 4칸 이동
+// 조건
+// 0. 현재 K 상태에 방문한적 있는지 체크 (이미 방문했다면 최솟값이 될 수 없으므로 pass)
+// 1. 벽 vs 빈 칸 체크
+// 2. 낮 vs 밤 체크   (낮에만 벽 부수기 가능)
+// 3. 부술 수 있는지 체크  (K개까지 벽 부수기 가능)
+public class boj_16933_26 {
+    private static final int WALL = 1;
+    private static int[][] dir = {{1, 0}, {0, -1}, {-1, 0}, {0, 1}};
+    private static int N,M,K;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        K = Integer.parseInt(st.nextToken());
+        int[][] grid = new int[N][M];
+        for (int i=0; i<N; i++) {
+            String row = br.readLine();
+            for (int j=0; j<M; j++) {
+                grid[i][j] = row.charAt(j) - '0';
+            }
+        }
+        System.out.println(getMinRoute_bfs(grid));
+    }
+    private static int getMinRoute_bfs(int[][] grid) {
+        boolean[][][] visited = new boolean[N][M][K+1];
+        Queue<RouteInfo> que = new LinkedList<>();
+        que.add(new RouteInfo(0, 0, 1, K, true));
+        visited[0][0][K] = true;
+        while (!que.isEmpty()) {
+            RouteInfo curr = que.poll();
+            // 중지 조건
+            if (curr.row == N-1 && curr.col == M-1) {
+                return curr.moveCnt;
+            }
+            for (int i=0; i<4; i++) {
+                int nxtRow = curr.row + dir[i][1];
+                int nxtCol = curr.col + dir[i][0];
+                if (isOutOfBound(nxtRow, nxtCol)) continue;
+                if (grid[nxtRow][nxtCol] == WALL) {
+                    if (curr.remainCrushCnt <=0 ) continue;
+                    if (visited[nxtRow][nxtCol][curr.remainCrushCnt-1]) continue;
+                    visited[nxtRow][nxtCol][curr.remainCrushCnt-1] = true;
+                    if (curr.isAfternoon)    //낮이면
+                        que.add(new RouteInfo(nxtRow, nxtCol, curr.moveCnt + 1, curr.remainCrushCnt - 1, false));
+                    else    // 밤이면 낮 되기까지 기다리고 뚫면 되니까 +2
+                        que.add(new RouteInfo(nxtRow, nxtCol, curr.moveCnt + 2, curr.remainCrushCnt - 1, true));
+
+                } else {
+                    if (visited[nxtRow][nxtCol][curr.remainCrushCnt]) continue;
+                    visited[nxtRow][nxtCol][curr.remainCrushCnt] = true;
+                    que.add(new RouteInfo(nxtRow, nxtCol, curr.moveCnt + 1, curr.remainCrushCnt, !curr.isAfternoon));
+                }
+            }
+        }
+        return -1;
+    }
+    private static boolean isOutOfBound(int row, int col) {
+        return row<0 || row>=N || col <0 || col>=M;
+    }
+    /**
+     * 경로를 거치는데 가지고 다녀야할 정보들을 갖는 클래스
+     */
+    private static class RouteInfo {
+        int row;
+        int col;
+        int moveCnt;
+        int remainCrushCnt;
+        boolean isAfternoon;
+        RouteInfo (int r, int c, int moveCnt, int remainCrushCnt, boolean isAfternoon) {
+            this.row = r;
+            this.col = c;
+            this.moveCnt = moveCnt;
+            this.remainCrushCnt = remainCrushCnt;
+            this.isAfternoon = isAfternoon;
+        }
+    }
+}

--- a/yoonji/home/5/boj_16946_24.java
+++ b/yoonji/home/5/boj_16946_24.java
@@ -1,2 +1,112 @@
-package PACKAGE_NAME;public class boj_16946_24 {
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+// 벽부수고 이동하기4
+    // 벽을 중심으로 cnt를 세면, 중복되서 칸을 세게 됨. => 시간초과
+    // 1. empty를 기준으로 먼저 grouping한다.
+    // - groupedGrid에 groupId를 하나씩 늘려가며 인접하는 칸에 groupId를 대체한다.
+    // - groupId의 전체 크기를 HashMap에 <groupId, 전체 크기>로 저장한다.
+    // 2. 벽을 만나면 인접한 4칸에 대해 방문하며
+    // - 중복되지 않은 groupId가 있다면 set에 넣어준다.
+    // - set에서 groupId를 꺼내서, Map의 value를 모두 더해서 전체 인접 칸 합%10 으로 해당 value(1)를 대체한다.
+public class boj_16946_24 {
+    static final int WALL = 1;
+    static int N,M;
+    static int[][] grid;
+    static int[][] groupedGrid;
+    static int[] dirX = {0, -1, 0, 1};
+    static int[] dirY = {1, 0, -1, 0};
+    static boolean[][] visited;
+    static Map<Integer, Integer> groupIdLen  = new HashMap<>();
+    public static void main(String[] args) throws IOException {
+        init();
+        // 1.empty끼리 그룹화하기
+        int groupId = 2;
+        for (int r=0; r<N; r++) {
+            for (int c=0; c<M; c++) {
+                if (groupedGrid[r][c] == 0) groupEmpty_bfs(r, c, groupId++);
+            }
+        }
+        // 2. 벽을 만나면 네 방면 체크
+        checkMovableCntAndPrint();
+    }
+    private static void init() throws IOException{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        grid = new int[N][M];
+        groupedGrid = grid;
+        visited = new boolean[N][M];
+        for (int r=0; r<N; r++) {
+            String row = br.readLine();
+            for (int c=0; c<M; c++) {
+                grid[r][c] = row.charAt(c) - '0';
+            }
+        }
+    }
+    private static void checkMovableCntAndPrint() {
+        Set<Integer> groupIdSet;
+        StringBuilder answerSB = new StringBuilder();
+        for (int r=0; r<N; r++) {
+            for (int c = 0; c < M; c++) {
+                if (grid[r][c] == WALL) {
+                    groupIdSet = new HashSet<>();
+                    for (int i=0; i<4; i++) {
+                        int adjRow = r + dirY[i];
+                        int adjCol = c + dirX[i];
+                        if (isOutOfBound(adjRow, adjCol)) continue;
+                        if (groupedGrid[adjRow][adjCol] == WALL) continue;
+                        if (groupIdSet.contains(groupedGrid[adjRow][adjCol])) continue;
+                        groupIdSet.add(groupedGrid[adjRow][adjCol]);
+                    }
+                    int possibleMove = 1;
+                    if (!groupIdSet.isEmpty()) {
+                        for(int cnt: groupIdSet)
+                            possibleMove += groupIdLen.get(cnt);  // groupId의 전체 크기
+                    }
+                    answerSB.append(possibleMove % 10);
+                }
+                else answerSB.append(0);
+            }
+            answerSB.append("\n");
+        }
+        System.out.println(answerSB);
+    }
+    private static void groupEmpty_bfs(int r, int c, int groupId) {
+        Queue<GridLocationInfo> que = new LinkedList<>();
+        que.offer(new GridLocationInfo(r, c));
+        int cntLen = 1;
+        groupedGrid[r][c] = groupId;
+        visited[r][c] = true;
+        while (!que.isEmpty()) {
+            GridLocationInfo curr = que.poll();
+            for (int i = 0; i < dirX.length; i++) {
+                int nxtRow = curr.row + dirY[i];
+                int nxtCol = curr.col + dirX[i];
+                if (isOutOfBound(nxtRow, nxtCol)) continue;
+                if (visited[nxtRow][nxtCol]) continue;
+                if (grid[nxtRow][nxtCol] == 0) {
+                    visited[nxtRow][nxtCol] = true;
+                    groupedGrid[nxtRow][nxtCol] = groupId;
+                    cntLen++;
+                    que.offer(new GridLocationInfo(nxtRow, nxtCol));
+                }
+            }
+        }
+        groupIdLen.put(groupId, cntLen);
+    }
+    private static boolean isOutOfBound(int nxtRow, int nxtCol) {
+        return nxtRow<0 || nxtRow>=N || nxtCol<0 || nxtCol >= M;
+    }
+    private static class GridLocationInfo {
+        int row;
+        int col;
+        GridLocationInfo(int row, int col) {
+            this.row = row;
+            this.col = col;
+        }
+    }
 }

--- a/yoonji/home/5/boj_16946_24.java
+++ b/yoonji/home/5/boj_16946_24.java
@@ -1,0 +1,2 @@
+package PACKAGE_NAME;public class boj_16946_24 {
+}

--- a/yoonji/office/5/26/prg_영어끝말잇기.java
+++ b/yoonji/office/5/26/prg_영어끝말잇기.java
@@ -1,0 +1,2 @@
+package PACKAGE_NAME;public class prg_영어끝말잇기 {
+}

--- a/yoonji/office/5/26/prg_영어끝말잇기.java
+++ b/yoonji/office/5/26/prg_영어끝말잇기.java
@@ -1,2 +1,53 @@
-package PACKAGE_NAME;public class prg_영어끝말잇기 {
+import java.util.*;
+public class prg_영어끝말잇기 {
+    public int[] solution (int n, String[] words) {
+        Set<String> wordSet = new HashSet<>();
+        int[] answer = new int[2];
+        int endChar = words[0].charAt(words[0].length() - 1);
+        wordSet.add(words[0]);
+        for (int i = 1; i < words.length; i++) {
+            if (endChar != words[i].charAt(0) || wordSet.contains(words[i])) {
+                int personNum = (i % n) + 1;
+                int turnCnt = (i / n) +1;
+                answer[0] = personNum;
+                answer[1] = turnCnt;
+                break;
+            }
+            wordSet.add(words[i]);
+            endChar = words[i].charAt(words[i].length() - 1);
+        }
+        return answer;
+    }
+    // 검사
+    // 이전에 나온 단어인가?
+    // 이전 단어의 마지막 문자로 시작하는가?
+    // => if 탈락) 자신의 번호와 차례번호 지정.
+    // n번째면, 1로 넘겨야함.
+    // 1로 다시 리셋하면서, 차례 번호+1
+    public int[] myFirstSolution(int n, String[] words) {
+        int[] answer = new int[2];
+        List<String> talkedWords = new ArrayList<>();
+        talkedWords.add(words[0]);
+        int currNum = 1;
+        int turnCnt = 1;
+        char beforeChar = words[0].charAt(words[0].length()-1);
+        for (int i=1; i<words.length; i++) {
+            currNum++;
+            if (currNum > n) {
+                currNum=1;
+                turnCnt++;
+            }
+            String currWord = words[i];
+            if (talkedWords.contains(currWord) || beforeChar != currWord.charAt(0)) {
+                answer[0] = currNum;
+                answer[1] = turnCnt;
+                break;
+            }
+            else {
+                talkedWords.add(currWord);
+                beforeChar = currWord.charAt(currWord.length()-1);
+            }
+        }
+        return answer;
+    }
 }

--- a/yoonji/office/5/26/prg_캐시.java
+++ b/yoonji/office/5/26/prg_캐시.java
@@ -1,0 +1,2 @@
+package PACKAGE_NAME;public class prg_캐시 {
+}

--- a/yoonji/office/5/26/prg_캐시.java
+++ b/yoonji/office/5/26/prg_캐시.java
@@ -1,2 +1,55 @@
-package PACKAGE_NAME;public class prg_캐시 {
+import java.util.LinkedList;
+import java.util.List;
+// 최근 값을 뒤에 저장한다.
+// 이미 캐시에 있다면, 최근 위치로 옮긴다. (제거 후 추가)
+public class prg_캐시 {
+    public int solution(int cacheSize, String[] cities) {
+        List<String> caches = new LinkedList<>();
+        int time = 0;
+        for (int i=0; i<cities.length; i++) {
+            String city = cities[i].toLowerCase();
+            // remove()-> boolean 여부로 contains 체크
+            if (caches.remove(city)) {  // 캐시에 있다면
+                caches.add(city);   // 뒤에 있는게 제일 최근
+                time++;
+            } else {
+                if (caches.size() > cacheSize) {                // 사이즈가 넘으면
+                    caches.remove(0);
+                }
+                caches.add(city);
+                time+=5;
+            }
+        }
+        return time;
+    }
+    /* 기존 풀이...
+    public int solution(int cacheSize, String[] cities) {
+        int takenTime = 0;
+        List<String> citiesCache = new LinkedList<>();
+        Map<String, Integer> citiesLocation = new HashMap<>();
+        for (int i=0; i<cities.length; i++) {
+            // map의 key로 있는지 찾고, 그 위치를 index로 List에서 지울까?
+            String city = cities[i].toLowerCase();
+            if (citiesLocation.containsKey(city)) {
+                // int location = citiesLocation.get(city);
+                // 제거
+                citiesCache.remove(city);   // String으로 삭제
+                citiesCache.add(city);
+                citiesLocation.put(city, 0);
+                takenTime+=1;
+            } else {
+                // 추가
+                // System.out.println(citiesLocation);
+                citiesCache.add(city);
+                citiesLocation.put(city, 0);
+                // 넣었는데 넘친 경우
+                if (citiesCache.size() > cacheSize) {
+                    String removedCity = citiesCache.remove(0);
+                    citiesLocation.remove(removedCity);
+                }
+                takenTime+=5;
+            }
+        }
+        return takenTime;
+    }*/
 }

--- a/yoonji/office/5/26/prg_피로도.java
+++ b/yoonji/office/5/26/prg_피로도.java
@@ -1,0 +1,34 @@
+public class prg_피로도 {
+    int max = Integer.MIN_VALUE;
+    boolean[] visited;
+    private void dfs(int depth, int k, int[][] dungeons) {
+        // base case
+        if(depth == dungeons.length) {
+            max = depth;
+            return;
+        }
+        // recur
+        for (int i = 0; i < dungeons.length; i++) {
+            if (visited[i]) continue;
+            if (k < dungeons[i][0]) {
+                max = Math.max(max, depth);
+                continue;
+            }
+            visited[i] = true;
+            dfs(depth + 1, k - dungeons[i][1] , dungeons);
+            visited[i] = false;
+        }
+    }
+    public int solution(int k, int[][] dungeons) {
+        visited = new boolean[dungeons.length];
+        dfs(0, k, dungeons);
+        return max;
+    }
+    public static void main(String[] args) {
+        prg_피로도 t = new prg_피로도();
+        //int solution = t.solution(80, new int[][]{{80, 20}, {50, 40}, {30, 10}});
+        int solution2 = t.solution(40, new int[][]{{40, 20}, {10, 10}, {10, 10}, {10, 10}, {10, 10}});
+//        System.out.println(solution);
+        System.out.println(solution2);
+    }
+}


### PR DESCRIPTION
## boj 벽부수고 이동하기2
### 설계
 * K-?개를 부수고 이동한 경로들 / 안부수고 이동한 경로들 중 가장 가까운 최솟값을 구하려면
 * 각각의 방문처리를 따로 해줘야 한다.
 * visited는 3차원으로, boolean[N][M][K+1] 어야 한다.
 * 다 부수고 특정 칸에 먼저 도착해도, 이후에 N,M에 도달하지 못하는 경로일 수 있기 때문에!
 * 아예 안부신 경우, K이고 부신 경우 그만큼 K-1

## boj 16933 벽부수고 이동하기3 (05.28. 추가)
### 설계
- 낮과 밤에 대한 상태 정보를 inner class에 추가해주었다.
- 벽을 만났을 때 밤에 대한 조건을 추가해주었다.
  - 벽인 경우 -> 밤인 경우 -> 낮이 되려면 `이동횟수+2`를 해준 후, `큐`에 추가한다. 
---

## prg 영어끝말잇기 & 캐시 
- 기존에 내가 시도한 방법과 페어 중 진행한 방법, 두가지 모두 추가해놓았다.

## prg 피로도
- 해당 문제는 DFS로 풀었으며, 종료 조건은 `던전 길이만큼 들어온 경우`이다.
- 만약 dfs 내 for문 중간에 현재 피로도가 i의 `최소 필요 피로도`보다 작다면, 해당 탐험(?)을 depth로 하여 뒤에 이어질 경우의 수만 건너뛰면 되므로 `continue`하면 된다.