### PR TITLE
Jungmin : Boj 16954 

### DIFF
--- a/chris-an/home/5.27/Boj_16954.java
+++ b/chris-an/home/5.27/Boj_16954.java
@@ -1,0 +1,71 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.Queue;
+
+public class Boj_16954 {
+    static char board[][] = new char[8][8];;
+    static boolean visited[][][]  = new boolean[8][8][9];
+    static int[] dx = {-1, -1, 0, 1, 1, 1, 0, -1, 0}; // 시계방향
+    static int[] dy = {0, 1, 1, 1, 0, -1, -1, -1, 0};
+
+    static class CharacterLoc{
+        int x;
+        int y;
+        int downCnt;
+
+        public CharacterLoc(int x, int y, int downCnt) {
+            this.x = x;
+            this.y = y;
+            this.downCnt = downCnt;
+        }
+    }
+
+    private static void bfs() {
+        Queue<CharacterLoc> queue = new LinkedList<>();
+
+        queue.offer(new CharacterLoc(7, 0, 0));
+        visited[7][0][0] = true;
+
+        while(!queue.isEmpty()) {
+            CharacterLoc point = queue.poll();
+            int curX = point.x;
+            int curY = point.y;
+            int curDownCnt = point.downCnt;
+
+            if(curX == 0 && curY == 7) {
+                System.out.println(1);
+                return;
+            }
+
+            for(int i = 0; i < 9; i++) {
+                int nx = curX + dx[i];
+                int ny = curY + dy[i];
+                int nDownCnt = Math.min(curDownCnt + 1, 8);
+
+                if(!isPossible(nx, ny)) continue; // 유동 가능한 범위 check
+
+                if(nx - curDownCnt >= 0 && board[nx - curDownCnt][ny] == '#') continue; // 벽이라 pass
+                if(nx - curDownCnt - 1 >= 0 && board[nx - curDownCnt - 1][ny] == '#') continue; // 내려오는 벽에 닿아서 pass
+
+                if(visited[nx][ny][nDownCnt]) continue;
+
+                visited[nx][ny][nDownCnt] = true;
+                queue.offer(new CharacterLoc(nx, ny, nDownCnt));
+            }
+        }
+        System.out.println(0);
+        return;
+    }
+
+    static boolean isPossible(int x, int y) {
+        return x >= 0 && y >= 0 && x < 8 && y < 8;
+    }
+
+    public static void main(String[] args) throws NumberFormatException, IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        for (int i = 0; i < 8; i++) board[i] = br.readLine().toCharArray();
+        bfs();
+    }
+}

--- a/chris-an/home/5.27/Boj_16954_2.java
+++ b/chris-an/home/5.27/Boj_16954_2.java
@@ -1,0 +1,77 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.Queue;
+
+public class Boj_16954_2 {
+    public static char[][] map = new char[8][8];
+    static int[] dx = {-1, -1, 0, 1, 1, 1, 0, -1, 0}; // 시계방향
+    static int[] dy = {0, 1, 1, 1, 0, -1, -1, -1, 0};
+
+    public static class CharacterLoc {
+        int x;
+        int y;
+
+        public CharacterLoc(int x, int y) {
+            this.x = x;
+            this.y = y;
+        }
+    }
+
+    public static boolean bfs() {
+        Queue<CharacterLoc> queue = new LinkedList<>();
+
+        boolean[][] visited;
+        queue.add(new CharacterLoc(7, 0));
+
+        while (!queue.isEmpty()) {
+            int movedInOneTurnCnt = queue.size();
+            visited = new boolean[8][8];
+
+            for (int i = 0; i < movedInOneTurnCnt; i++) { // * 이 부분 때문에 초기 로직이 안되서 계속 삽질을 많이 했음.
+                CharacterLoc cur = queue.poll();
+
+                if (map[cur.x][cur.y] == '#') continue; // 벽이 내려오면서 걸렸다? pass
+                if (cur.x == 0 && cur.y == 7) return true;
+
+                for (int k = 0; k < 9; k++) {
+                    int nx = cur.x + dx[k];
+                    int ny = cur.y + dy[k];
+
+                    if (!isPossible(nx, ny)) continue;
+                    if (visited[nx][ny] || map[nx][ny] == '#') continue;
+
+                    queue.add(new CharacterLoc(nx, ny));
+                    visited[nx][ny] = true;
+                }
+            }
+            remapBoard(); // * 위의 movedInOneTurnCnt for 문을 통해서, remapBoard 를 진행한 부분이 중요.
+        }
+        return false;
+    }
+
+    public static void remapBoard() {
+        for (int i = 7; i >= 0; i--) {
+            for (int j = 0; j < 8; j++) {
+                if (map[i][j] == '#') {
+                    map[i][j] = '.';
+
+                    if (i != 7) {
+                        map[i + 1][j] = '#';
+                    }
+                }
+            }
+        }
+    }
+
+    static boolean isPossible(int x, int y) {
+        return x >= 0 && y >= 0 && x < 8 && y < 8;
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        for (int i = 0; i < 8; i++) map[i] = br.readLine().toCharArray();
+        System.out.println(bfs() ? 1 : 0);
+    }
+}


### PR DESCRIPTION
## 움직이는 미로 탈출
처음 설계는 방문처리 없이, bfs를 돌리면서 벽이 행으로 한 칸 내려가게끔 board 내 벽 위치를 재 배치를 하면서 계속 루프를 돌려주는 식으로 코드를 짰습니다.  
첫 번째 맞이한 로직 상 오류는 board 값이 계속 변해서 class 내에 각 큐일 때, board 위치를 가지고 큐를 넣을 수 있게 코드를 수정이 필요했습니다. 하지만, 메모리 초과가 났습니다.
메모리 초과가 된 건, 1초에 벽이 한 번 씩 행으로 내려오는 경우를 안될 땐 들어가지 않게끔 예외 조건을 막아줘야하는데 제가 짠 로직 상 큐에 8방면을 다 집어 넣고, 빼면서 확인하는 로직이라 메모리 초과가 났던 거 같습니다.

이동할 때, 8방면에 벽 있는 지 check 도 해주고, 이 후에 벽이 재배치 했을 경우, 닿으면 안되는 상황까지 고려해서 큐에 집어 넣어야 했습니다. 그리고 각 상황에 맞게 벽이 얼마나 내려왔는 지 status 까지 알고 있어야 함으로, 문제가 더 까다로운데 단순하게 생각했던 거 같습니다.

수정된 로직은 board 의 재배치 없이 벽이 이동한 횟수를 방문체크와 class에 가지고 다니면서 bfs 돌리는 방식으로 구현했습니다.

>  두 번째로 commit 해서 올린 코드가 제가 처음 접근했던 코드와 유사합니다. 메모리 초과 됐던 부분을 for문 하나로 처리했으면, 수월하게문제가 풀렸을 거 같습니다..