### PR TITLE
yoonji, jeongwoo: prg 순위검색/ prg 후보키(진행중) , yoonji : prg 모음사전

### DIFF
--- a/yoonji/Implementation/String/prg_모음사전.java
+++ b/yoonji/Implementation/String/prg_모음사전.java
@@ -1,0 +1,31 @@
+package Implementation.String;
+
+// 규칙을 찾아서 풀어야 하는 문제
+// 5번째자리 바뀔 때 : +1씩
+// 4번째자리 바뀔 때 : 1+ 5^1씩(문자 5개가 1자리 바뀜) = 6씩
+// 3번째자리 바뀔 때 : 6+ 5^2씩(문자 5개가 2자리 바뀜) = 31씩
+// 2번째자리 바뀔 때 : 31+ 5^3씩(문자 5개가 3자리 바뀜) = 156씩
+// 1번째자리 바뀔 때 : 156+ 5^4씩(문자 5개가 4자리 바뀜) = 781씩
+/* 아이디어
+1. 자릿수에 따른 규칙을 위한 배열과 언급될 문자열 변수를 선언한다.
+- 각 자릿수에 따라 바뀌는 규칙이 다르므로,
+- 문자에 따라 순서가 다르므로 (A-E-I-O-U)
+2. 단어의 길이만큼 반복문을 돌면서, word 문자에서 char 순서(0~4) * 자릿수에 따른 규칙 숫자를 더해서
+3. 최종 값이 word의 순서
+*/
+public class prg_모음사전 {
+    public int solution(String word) {
+        int[] digitRule = {781, 156, 31, 6, 1}; // 첫번째 자리 바뀔 때 781
+        String dict = "AEIOU";
+
+        //AAAA(자릿수만큼) 의 수는 디폴트 (길이만큼)
+        int answer = word.length(); // ex) AAAAE -> AAAAA에 대한 5로 세팅하고!
+
+        // 각 숫자의 증가 규칙에 따라 ++
+        for (int i=0; i<word.length(); i++) {
+            answer += dict.indexOf(word.charAt(i)) * digitRule[i];
+            System.out.println(answer);
+        }
+        return answer;
+    }
+}

--- a/yoonji/Implementation/String/prg_순위검색.java
+++ b/yoonji/Implementation/String/prg_순위검색.java
@@ -1,0 +1,98 @@
+package Implementation.String;
+
+import java.util.*;
+
+// 지원자들의 지원 조건 선택 => 해당 조건에 맞는 지원자 인원수
+// 조건 + 코테 점수 X점 이상
+// 각 문의조건에 해당하는 사람들의 숫자를 순서대로 배열로 리턴
+// 배열 길이 50000
+// info : 언어 직군 경력 소울푸드 코테점수(1~100000)
+// query 길이 100000이하
+// query: 조건 and 조건 and 조건 and 조건 점수
+// 조건이 -이면 고려X ex) cpp and - and senior and pizza 500
+/*
+- 기존 아이디어 (10초이상 시간초과)
+1. 리스트에 Class로 넣고 코테점수기준으로 정렬
+2. 점수 기준 정렬된 클래스에 대해 query 돌면서 조건에 해당(이상의 점수)하는 지원자 인원수 구하기
+- 새 아이디어 (dfs)
+++ dfs에서 '-'의 경우의 수도 추가하는 이유 : query에서 '-'는 해당 조건은 고려하지 않겠다는 의미이므로, '-'를 포함한 모든 경우의 수를 구해야한다.
+쿼리의 조건과 같은 경우를 찾을 base == info 배열 이용해서 dfs로 모든 경우의 수를 구해놓는다. (있거나 없거나(-))
+1. dfs로 info 돌면서 경우(4개:lang, pos, career, food)를 구해놓고, 이에 해당하는 코테점수를 value로 가지는 Map에 pt
+2. query돌면서 해당하는 게 Map의 key로 있으면 그 key의 value의 코테점수들과 비교한다.
+ */
+public class prg_순위검색 {
+    private static Map<String, ArrayList<Integer>> applicantInfoMap = new HashMap<>();
+    private static String[] applicantInfo = new String[5];
+    private static String[] emptyArr;
+    private static Integer testScore =0;
+    public int[] solution(String[] info, String[] query) {
+        int[] answer = new int[query.length];
+        // 1. 모든 info에 대해 dfs로 경우의 수를구한다.
+        for(String i: info) {
+            emptyArr = new String[4];
+            applicantInfo = i.split(" ");
+            testScore = Integer.parseInt(applicantInfo[4]);
+            getApplicantInfoCase_dfs(0);    // depth는 4개
+        }
+
+        for (String str: applicantInfoMap.keySet()) {
+//            System.out.println("탐색 키: "+ str);
+            Collections.sort(applicantInfoMap.get(str));
+        }
+
+        // 2. query 돌면서 해당 info가 key에 있는지 확인
+        for (int i=0; i<query.length; i++) {
+            String[] infoOfQuery = query[i].split(" and ");
+            int limitScore = Integer.parseInt(infoOfQuery[3].split(" ")[1]);
+            infoOfQuery[3] = infoOfQuery[3].split(" ")[0];
+            String strInfoOfQuery = infoOfQuery[0] + infoOfQuery[1] + infoOfQuery[2] + infoOfQuery[3];
+
+            // TODO: 2022-06-27 왜 전체 map에 대해 value를 먼저 Sorting해야되?? query에 해당하는 것만 sorting하는게 더 적은 수 아닌가?
+            if (applicantInfoMap.containsKey(strInfoOfQuery)) {
+//                System.out.print("key= "+ strInfoOfQuery+": ");
+                ArrayList<Integer> scores = applicantInfoMap.get(strInfoOfQuery);
+
+//                Collections.sort(scores);
+
+                answer[i] = scores.size() - searchScoreEqualOrGreaterThanLimitscore(scores, limitScore);
+            }
+        }
+        return answer;
+    }
+
+    private int searchScoreEqualOrGreaterThanLimitscore(ArrayList<Integer> scores, int limit) {
+        int left = 0;
+        int right = scores.size()-1;
+        while (left <= right) {
+            int mid = (left+right)/2;
+            if (scores.get(mid) < limit) {
+                left = mid+1;
+            } else {
+                right = mid-1;
+            }
+        }
+        // 같거나 클 때 right가 왼쪽으로 이동하고, 그 후에 left, right가 교차한거면 left가 정답.
+        return left;
+    }
+
+    private void getApplicantInfoCase_dfs(int depth) {
+        if (depth == 4) {
+            String applicantInfoStr = String.join("", emptyArr);
+            if (!applicantInfoMap.containsKey(applicantInfoStr)) applicantInfoMap.put(applicantInfoStr, new ArrayList<>());
+            applicantInfoMap.get(applicantInfoStr).add(testScore);
+
+            return;
+        }
+        emptyArr[depth] = applicantInfo[depth];
+        getApplicantInfoCase_dfs(depth+1);
+        emptyArr[depth] = "-";  // 고려하지 않는 경우도 체크해줘야하므로
+        getApplicantInfoCase_dfs(depth+1);
+    }
+
+    public static void main(String[] args) {
+        prg_순위검색 t = new prg_순위검색();
+        int[] solution = t.solution(new String[]{"java backend junior pizza 150", "python frontend senior chicken 210", "python frontend senior chicken 150", "cpp backend senior pizza 260", "java backend junior chicken 80", "python backend senior chicken 50"},
+                new String[]{"java and backend and junior and pizza 100", "python and frontend and senior and chicken 200", "cpp and - and senior and pizza 250", "- and backend and senior and - 150", "- and - and - and chicken 100", "- and - and - and - 150"});
+        System.out.println(Arrays.toString(solution));
+    }
+}

--- a/yoonji/Implementation/String/prg_후보키.java
+++ b/yoonji/Implementation/String/prg_후보키.java
@@ -1,4 +1,4 @@
-package Implement.String;
+package Implementation.String;
 import java.util.*;
 
 // 유일성 + 최소성
@@ -65,10 +65,10 @@ public class prg_후보키 {
                 // 03, 023 불가능.   13, 023 가능  (size가 작은 후보키가 큰 후보키에 완전 포함되는 경우만 최소성을 위반한 것.
             /*boolean isContains = true;
             Arrays.sort(idxArr);
-            String idxStr = Arrays.toString(idxArr).replaceAll("[^0-9]", "");
-            for (String candidateKey : columnsOfCandidate) {
+            Implementation.String idxStr = Arrays.toString(idxArr).replaceAll("[^0-9]", "");
+            for (Implementation.String candidateKey : columnsOfCandidate) {
                 System.out.println("====");
-                String sortedKey = Stream.of(candidateKey.split(""))
+                Implementation.String sortedKey = Stream.of(candidateKey.split(""))
                         .sorted()
                         .collect(Collectors.joining());
                 System.out.println("기존키: "+sortedKey+ ", 새로운 키: "+idxStr);
@@ -90,18 +90,18 @@ public class prg_후보키 {
             return;*/
         }
 
-           /* List<String> newCandidate = List.of(idxStr);
+           /* List<Implementation.String> newCandidate = List.of(idxStr);
             System.out.println("새 후보키");
-            for (String s: newCandidate) System.out.print(s+",");
+            for (Implementation.String s: newCandidate) System.out.print(s+",");
             System.out.println();
             System.out.println("기존 후보키");
-            for (String s: columnsOfCandidate) System.out.print(s+",");
+            for (Implementation.String s: columnsOfCandidate) System.out.print(s+",");
             System.out.println("====");*/
 
-            /*List<String> removedKey = new ArrayList<>();
-            for (String candidateKey : columnsOfCandidate) {
-                String longKey = candidateKey.length() < columnSize? idxStr: candidateKey;
-                String shortKey = candidateKey.length() > columnSize? idxStr: candidateKey;
+            /*List<Implementation.String> removedKey = new ArrayList<>();
+            for (Implementation.String candidateKey : columnsOfCandidate) {
+                Implementation.String longKey = candidateKey.length() < columnSize? idxStr: candidateKey;
+                Implementation.String shortKey = candidateKey.length() > columnSize? idxStr: candidateKey;
                 for (int i=0; i<shortKey.length(); i++) {
                     if (!longKey.contains(shortKey.charAt(i)+""))
                         isContains = false;
@@ -120,8 +120,8 @@ public class prg_후보키 {
 
 
             /*    for (int idx : idxArr) {
-                    for (String candidateKey : columnsOfCandidate) {
-                        if (String.valueOf(idx).equals(candidateKey)) break;
+                    for (Implementation.String candidateKey : columnsOfCandidate) {
+                        if (Implementation.String.valueOf(idx).equals(candidateKey)) break;
                         else isContains = false;
                     }
                     isContains = true;

--- a/yoonji/Implementation/String/prg_후보키.java
+++ b/yoonji/Implementation/String/prg_후보키.java
@@ -1,0 +1,156 @@
+package Implement.String;
+import java.util.*;
+
+// 유일성 + 최소성
+// 유일한 데이터가 되도록 만드는 키.
+// 그 키는 최대한 최소의 갯수로 만들어야한다.
+// 즉, 2개와 3개가 가능하다면 더 적은 수!
+// 칼럼길이 1~8
+// 로우길이 1~20
+// 데이터 길이 1~8 (소문자&숫자)
+//중복 튜플X
+// 1개씩, 2개씩, 3개씩, .. relation.length씩
+/*
+- 아이디어
+1. 자료구조에 칼럼 별로 데이터를 저장한다.  ex) 100,200,300,400,500,600
+2. (정렬)
+3. 각 size(1~칼럼 수)만큼 반복문을 돌면서, dfs 메서드를 호출한다.
+4. dfs: 모든 짝지어질 수 있는 경우의 수를 size(깊이)만큼 구하고,
+   - base case: 배열에 들어간 값들을 String으로 이어붙여서 List에 넣으면서 이미 있는 값인지 확인한다.
+      - 있으면, Candidate 후보로 되는 것이므로 boolean 배열에 해당하는 칼럼을 true로 표시하고, answer++
+      - 이후 size에서는 true인 배열은 pass해서 호출한다.
+   + 추가) 유일성을 만족하는 후보키 중 size가 작은 후보키를 포함하는 후보키는 최소성을 위반하는 것이다.
+ */
+public class prg_후보키 {
+//    private static int[] columnsOfCandidate;
+    private static List<ArrayList<Integer>> colsOfCandidate = new ArrayList<>();
+//    private static boolean[] isCandidate;
+
+    private static boolean[] visited;
+//    private static int answer = 0;
+
+    public int solution(String[][] relation) {
+//        columnsOfCandidate = new int[relation[0].length];
+//        isCandidate = new boolean[relation[0].length];
+        for (int columnSize= 1; columnSize <= relation[0].length; columnSize++) {
+            visited = new boolean[relation[0].length];
+            List<Integer> idxArr = new ArrayList<>(columnSize);
+            getCase_Dfs(columnSize, 0, 0, relation, idxArr);
+        }
+        return colsOfCandidate.size();
+    }
+
+    private void getCase_Dfs(int columnSize, int depth, int startIdx, String[][] relation, List<Integer> idxArr) {
+        // 후보키인지 아닌지
+        if (depth == columnSize) {
+//            List<Integer> keys = new HashSet<>();
+
+            // 최소성?
+            for(ArrayList<Integer> key : colsOfCandidate) {
+                if (idxArr.containsAll(key)) {
+                    System.out.println(idxArr + "키는 " + key + "키를 포함합니다.");
+                    return;
+                }
+            }
+// 유일성?
+            Set<String> keys = new HashSet<>();
+            for (int i = 0; i < relation.length; i++) {
+                String key = "";
+                for (int idx : idxArr) {
+                    key += relation[i][idx];
+                }
+                if (keys.contains(key)) return;
+                keys.add(key);
+            }
+                // 03, 023 불가능.   13, 023 가능  (size가 작은 후보키가 큰 후보키에 완전 포함되는 경우만 최소성을 위반한 것.
+            /*boolean isContains = true;
+            Arrays.sort(idxArr);
+            String idxStr = Arrays.toString(idxArr).replaceAll("[^0-9]", "");
+            for (String candidateKey : columnsOfCandidate) {
+                System.out.println("====");
+                String sortedKey = Stream.of(candidateKey.split(""))
+                        .sorted()
+                        .collect(Collectors.joining());
+                System.out.println("기존키: "+sortedKey+ ", 새로운 키: "+idxStr);
+                if (sortedKey.contains(idxStr)) {
+                    if (idxStr.length() < sortedKey.length()) {
+                        columnsOfCandidate.remove(candidateKey);
+                        columnsOfCandidate.add(idxStr);
+                        return;
+                    }
+                } else if (idxStr.contains(sortedKey)) {
+                    if (idxStr.length() < sortedKey.length()) {
+                        columnsOfCandidate.remove(candidateKey);
+                        columnsOfCandidate.add(idxStr);
+                        return;
+                    }
+                }
+            }
+            columnsOfCandidate.add(idxStr);
+            return;*/
+        }
+
+           /* List<String> newCandidate = List.of(idxStr);
+            System.out.println("새 후보키");
+            for (String s: newCandidate) System.out.print(s+",");
+            System.out.println();
+            System.out.println("기존 후보키");
+            for (String s: columnsOfCandidate) System.out.print(s+",");
+            System.out.println("====");*/
+
+            /*List<String> removedKey = new ArrayList<>();
+            for (String candidateKey : columnsOfCandidate) {
+                String longKey = candidateKey.length() < columnSize? idxStr: candidateKey;
+                String shortKey = candidateKey.length() > columnSize? idxStr: candidateKey;
+                for (int i=0; i<shortKey.length(); i++) {
+                    if (!longKey.contains(shortKey.charAt(i)+""))
+                        isContains = false;
+                }
+                if (isContains) {
+                    removedKey.add(longKey);
+                    columnsOfCandidate.add(shortKey);
+
+                    if (candidateKey.equals())
+                            columnsOfCandidate.remove(shortKey);
+                            columnsOfCandidate.add(longKey);
+                        }
+                    } else {
+
+                    }*/
+
+
+            /*    for (int idx : idxArr) {
+                    for (String candidateKey : columnsOfCandidate) {
+                        if (String.valueOf(idx).equals(candidateKey)) break;
+                        else isContains = false;
+                    }
+                    isContains = true;
+                }
+                if (isContains) return;*/
+//            }
+//            columnsOfCandidate.add(idxStr);
+
+        // for문을 돌면서 set에 넣는다.
+        // for문 : 칼럼 =>
+        for (int i=startIdx; i<relation[0].length; i++) {
+            if (visited[i]) continue;
+
+            idxArr.add(depth,i);
+            visited[i] = true;
+            getCase_Dfs(columnSize, depth+1, i+1, relation, idxArr);
+            visited[i] = false;
+        }
+    }
+    public static void main(String[] args) {
+        prg_후보키 t = new prg_후보키();
+        String[][] info = {{"100","ryan","music","2"}, {"200","apeach","math","2"}, {"300","tube","computer","3"}, {"400","con","computer", "4"}, {"500","muzi","music","3"}, {"600","apeach","music","2"}};
+        String[][] info2 = { {"a","1","aaa","c","ng"},
+                {"a","1","bbb","e","g"},
+                {"c","1","aaa","d","ng"},
+                {"d","2","bbb","d","ng"}};
+        String[][] info3 = {{"a","1","aaa","c","ng"}, {"b", "1", "bbb", "c", "g"}, {"c", "1", "aaa", "d", "ng"}, {"d", "2", "bbb","d","ng"}};
+        int solution = t.solution(info);
+        System.out.println(solution);
+        System.out.println("전체 후보키: "+prg_후보키.colsOfCandidate);
+    }
+}

--- a/yoonji/home/6/mono/prg_행렬테두리회전하기.java
+++ b/yoonji/home/6/mono/prg_행렬테두리회전하기.java
@@ -1,0 +1,2 @@
+package PACKAGE_NAME;public class prg_행렬테두리회전하기 {
+}


### PR DESCRIPTION
## prg 순위검색
### 설계
- 정확성과 효율성 모두 체크해야하는 문제
1. 각 4개의 칼럼의 값들을 '-' 와 함께 섞어서 경우의 수를 모두 구한다. (dfs로 접근)
  - 쿼리에서는 '-'인 경우 해당 칼럼을 고려하지 않는 것이고 여러 쿼리에 해당하는 지원자가 있을 수 있기 때문에 모든 경우의 수를 구할 때 '-'를 포함시킨다.
  - 탐색하며 4자리가 완성되면 하나의 `String`으로 `map`의 key에 두고, value에는 코테 점수를 추가하도록 `ArrayList`로 선언한다. 
2. 모든 key의 value들에 대해 `sort` (왜 모든 key에 대해 진행해야하는지는 여전히 의문)
3. 인자 `query`를 돌면서 동일한 key값의 (정렬된) value들에 대해 이분 탐색으로 값을 찾는다.

> ➕ 추가
> 가능한 모든 query의 개수는 4 * 3 * 3 * 3 = 108가지이고, query는 최대 100000개 주어지는데, 쿼리는 중복될 수 있기 때문에 **정렬한 key를 재 정렬할 수도 있겠다.** 그러므로 어떤 경우에는 미리 정렬하는 것이 더 적은 경우의 수로 정렬이 이루어질 것이다.


## prg 후보키 (진행중)
### 설계
- size(1부터)만큼 반복하면서 dfs를 호출한다. 
  - size까지 depth가 들어갔다면 그때 후보키에 해당하는 칼럼의 필드를 `Set`에 넣으면서 중복성을 체크한다.(유일성) + 최소성을 고려해야한다. 
- 관건은 최소성이다. 최소성의 조건은 아래와 같다.
> 예제) 
> 0,1번째 칼럼이 후보키이고,  0,1,2번째 칼럼이 후보키이면  0,1번째 칼럼만 고려한다. (완전 포함되므로)
> 0,2번째 칼럼이 후보키이고, 0,1,3번째 칼럼이 후보키이면 두 후보키 모두 고려해야한다. 
- 문제는 먼저 들어간 후보키가 size가 항상 작은 것이 아니기 때문에 서로 포함되는지 체크를해야한다.
  - 완전 포함되는가?
  - size가 더 작은가?
## prg 모음사전
### 설계
1. 자릿수에 따른 규칙을 위한 배열과 언급될 문자열 변수를 선언한다.
- 각 자릿수에 따라 바뀌는 규칙이 다르므로,
- 문자에 따라 순서가 다르므로 (A-E-I-O-U)
2. 단어의 길이만큼 반복문을 돌면서, word 문자에서 char 순서(0~4) * 자릿수에 따른 규칙 숫자를 더해서
3. 최종 값이 word의 순서
### 후기
- 문제를 잘못 체크하고 해당 문제를 풀었습니다 (but 나중에 다시 풀어봐야할 문제..)
- 규칙을 찾는 건 결국 다 써봐야하는 것도 맞지만 규칙 찾기 어려운 것 같습니다.